### PR TITLE
Updating to pact standalone core 1.22.1

### DIFF
--- a/Build/Download-Standalone-Core.ps1
+++ b/Build/Download-Standalone-Core.ps1
@@ -26,7 +26,7 @@ New-Item -ItemType directory -Path $OutputPath | Out-Null
 
 Import-Module -Name $7ZipSnapIn
 
-$StandaloneCoreVersion = '1.19.0'
+$StandaloneCoreVersion = '1.22.1'
 $StandaloneCoreDownloadBaseUri = "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v$StandaloneCoreVersion"
 
 # Download and extract the Windows core


### PR DESCRIPTION
[This issue](https://github.com/pact-foundation/pact-js/issues/131) is the showstopper of using pact in our company since we have a lot of environments in one URL root.

This issue has been fixed in the commit https://github.com/pact-foundation/pact-provider-verifier/commit/b765b00b9c57300e633afe6044a3459ebf81aeba

Please update nuget packages to resolve this issue in client libs.