### PR TITLE
Isolate the json serializer settings per PactBuilder object

### DIFF
--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
@@ -16,11 +16,11 @@ namespace PactNet.Tests.IntegrationTests
         {
             var pactConfig = new PactConfig();
 
-            PactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) =>
+            PactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
                     new MockProviderService(
                         baseUri => new RubyHttpHost(baseUri, "MyConsumer", "MyApi", pactConfig, host),
                         port, enableSsl,
-                        baseUri => new AdminHttpClient(baseUri)))
+                        baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings)))
                 .ServiceConsumer("FailureIntegrationTests")
                 .HasPactWith("MyApi");
 

--- a/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
@@ -16,11 +16,11 @@ namespace PactNet.Tests.IntegrationTests
         {
             var pactConfig = new PactConfig();
 
-            PactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) =>
+            PactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
                     new MockProviderService(
                         baseUri => new RubyHttpHost(baseUri, "MyConsumer", "MyApi", pactConfig, host),
                         port, enableSsl,
-                        baseUri => new AdminHttpClient(baseUri)))
+                        baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings)))
                 .ServiceConsumer("IntegrationTests")
                 .HasPactWith("MyApi");
 

--- a/PactNet.Tests/Mocks/MockHttpService/Host/RubyHttpHostTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Host/RubyHttpHostTests.cs
@@ -27,7 +27,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Host
 
             return new RubyHttpHost(
                 _mockCoreHost, 
-                new AdminHttpClient(baseUri, _fakeHttpMessageHandler));
+                new AdminHttpClient(baseUri, _fakeHttpMessageHandler, null));
         }
     
         [Fact]

--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
@@ -32,7 +32,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
                 },
                 port,
                 enableSsl,
-                baseUri => new AdminHttpClient(baseUri, _fakeHttpMessageHandler));
+                baseUri => new AdminHttpClient(baseUri, _fakeHttpMessageHandler, null));
         }
 
         [Fact]

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -75,7 +75,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) => mockMockProviderService);
 
             pactBuilder
                 .ServiceConsumer("Event Client")
@@ -92,7 +92,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) => mockMockProviderService);
 
             pactBuilder
                 .ServiceConsumer("Event Client")
@@ -111,7 +111,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -132,7 +132,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -153,7 +153,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -169,12 +169,17 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void MockService_WhenCalledWithJsonSerializerSettings_SetsTheGlobalApiSerializerSettings()
+        public void MockService_WhenCalledWithJsonSerializerSettings_MockProviderServiceFactoryIsInvokedWithJsonSerializerSettings()
         {
+            JsonSerializerSettings calledWithSerializerSettings = null;
             var serializerSettings = new JsonSerializerSettings();
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
+            {
+                calledWithSerializerSettings = jsonSerializerSettings;
+                return mockMockProviderService;
+            });
 
             pactBuilder
                 .ServiceConsumer("Event Client")
@@ -182,22 +187,20 @@ namespace PactNet.Tests
 
             pactBuilder.MockService(1234, serializerSettings);
 
-            Assert.Equal(serializerSettings, JsonConfig.ApiSerializerSettings);
-
-            //Reset the settings
-            JsonConfig.ApiSerializerSettings = new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                Formatting = Formatting.None
-            };
+            Assert.Equal(serializerSettings, calledWithSerializerSettings);
         }
 
         [Fact]
-        public void MockService_WhenCalledWithNoJsonSerializerSettings_DoesNotSetTheGlobalApiSerializerSettingsToNull()
+        public void MockService_WhenCalledWithNoJsonSerializerSettings_MockProviderServiceFactoryIsInvokedWithNullJsonSerializerSettings()
         {
+            var calledWithSerializerSettings = new JsonSerializerSettings();
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) =>
+            {
+                calledWithSerializerSettings = jsonSerializerSettings;
+                return mockMockProviderService;
+            });
 
             pactBuilder
                 .ServiceConsumer("Event Client")
@@ -205,13 +208,13 @@ namespace PactNet.Tests
 
             pactBuilder.MockService(1234);
 
-            Assert.NotNull(JsonConfig.ApiSerializerSettings);
+            Assert.Null(calledWithSerializerSettings);
         }
 
         [Fact]
         public void MockService_WhenCalledWithoutConsumerNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, host) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, host, jsonSerializerSettings) => Substitute.For<IMockProviderService>());
             pactBuilder
                 .HasPactWith("Event API");
 
@@ -221,7 +224,7 @@ namespace PactNet.Tests
         [Fact]
         public void MockService_WhenCalledWithoutProviderNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, hsot) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, host, jsonSerializerSettings) => Substitute.For<IMockProviderService>());
             pactBuilder
                 .ServiceConsumer("Event Client");
 
@@ -243,7 +246,7 @@ namespace PactNet.Tests
             const string testProviderName = "Event API";
             var mockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, host) => mockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, consumerName, providerName, host, jsonSerializerSettings) => mockProviderService);
             pactBuilder
                 .ServiceConsumer(testConsumerName)
                 .HasPactWith(testProviderName);
@@ -260,7 +263,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host) => mockMockProviderService)
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) => mockMockProviderService)
                 .ServiceConsumer("Event Client")
                 .HasPactWith("Event API");
 

--- a/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
+++ b/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
@@ -16,17 +16,25 @@ namespace PactNet.Mocks.MockHttpService
     {
         private readonly HttpClient _httpClient;
         private readonly IHttpMethodMapper _httpMethodMapper;
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
 
         internal AdminHttpClient(
             Uri baseUri,
-            HttpMessageHandler handler)
+            HttpMessageHandler handler,
+            JsonSerializerSettings jsonSerializerSettings)
         {
             _httpClient = new HttpClient(handler) { BaseAddress = baseUri };
             _httpMethodMapper = new HttpMethodMapper();
+            _jsonSerializerSettings = jsonSerializerSettings ?? JsonConfig.ApiSerializerSettings;
         }
 
         public AdminHttpClient(Uri baseUri) : 
-            this(baseUri, new HttpClientHandler())
+            this(baseUri, new HttpClientHandler(), null)
+        {
+        }
+
+        public AdminHttpClient(Uri baseUri, JsonSerializerSettings jsonSerializerSettings) :
+            this(baseUri, new HttpClientHandler(), jsonSerializerSettings)
         {
         }
 
@@ -52,7 +60,7 @@ namespace PactNet.Mocks.MockHttpService
 
             if (requestContent != null)
             {
-                var requestContentJson = JsonConvert.SerializeObject(requestContent, JsonConfig.ApiSerializerSettings);
+                var requestContentJson = JsonConvert.SerializeObject(requestContent, _jsonSerializerSettings);
                 request.Content = new StringContent(requestContentJson, Encoding.UTF8, "application/json");
             }
 

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -33,11 +33,16 @@ namespace PactNet.Mocks.MockHttpService
         }
 
         public MockProviderService(int port, bool enableSsl, string consumerName, string providerName, PactConfig config, IPAddress ipAddress)
+            : this(port, enableSsl, consumerName, providerName, config, ipAddress, null)
+        {
+        }
+
+        public MockProviderService(int port, bool enableSsl, string consumerName, string providerName, PactConfig config, IPAddress ipAddress, Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings)
             : this(
             baseUri => new RubyHttpHost(baseUri, consumerName, providerName, config, ipAddress),
             port,
             enableSsl,
-            baseUri => new AdminHttpClient(baseUri))
+            baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings))
         {
         }
 

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using PactNet.Configuration.Json;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
 using PactNet.Models;
@@ -11,11 +10,11 @@ namespace PactNet
     {
         public string ConsumerName { get; private set; }
         public string ProviderName { get; private set; }
-        private readonly Func<int, bool, string, string, IPAddress, IMockProviderService> _mockProviderServiceFactory;
+        private readonly Func<int, bool, string, string, IPAddress, JsonSerializerSettings, IMockProviderService> _mockProviderServiceFactory;
 
         private IMockProviderService _mockProviderService;
 
-        internal PactBuilder(Func<int, bool, string, string, IPAddress, IMockProviderService> mockProviderServiceFactory)
+        internal PactBuilder(Func<int, bool, string, string, IPAddress, JsonSerializerSettings, IMockProviderService> mockProviderServiceFactory)
         {
             _mockProviderServiceFactory = mockProviderServiceFactory;
         }
@@ -26,7 +25,7 @@ namespace PactNet
         }
 
         public PactBuilder(PactConfig config)
-            : this((port, enableSsl, consumerName, providerName, host) => new MockProviderService(port, enableSsl, consumerName, providerName, config, host))
+            : this((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings) => new MockProviderService(port, enableSsl, consumerName, providerName, config, host, jsonSerializerSettings))
         {
         }
 
@@ -76,12 +75,7 @@ namespace PactNet
                 _mockProviderService.Stop();
             }
 
-            if (jsonSerializerSettings != null)
-            {
-                JsonConfig.ApiSerializerSettings = jsonSerializerSettings;
-            }
-
-            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, ConsumerName, ProviderName, host);
+            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, ConsumerName, ProviderName, host, jsonSerializerSettings);
 
             _mockProviderService.Start();
 


### PR DESCRIPTION
Isolate the json serializer settings per PactBuilder object instead of using global settings.  This allows us to use multiple PactBuilder objects with different serialization settings for mocking multiple services at the same time.

For example:
I have a service (A) that depends on multiple other services (B + C) that I need to setup separate PactBuilder objects for so that I get separate pact mock services.  Service (B) requires special serialization settings in order to work properly, but changing the global serialization settings would also cause service (C) to use those same settings which won't work for service (C).  This change isolates the serialization settings per PactBuilder object so that each pact mock service can have its own serialization settings.