### PR TITLE
Add declaration of ProviderState to ease use of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ public class ProviderStateMiddleware
 ```
 
 ```c#
+public class ProviderState
+{
+    public string Consumer { get; set; }
+    public string State { get; set; }
+}
+```
+
+```c#
 public class XUnitOutput : IOutput
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
I was following along with the demo and I was initially unable to figure out where `ProviderState` was coming from, this simple update should save future users the trouble I had in looking through the repo to find out where `ProviderState` comes from.