### PR TITLE
Add link to PactNet Workshop to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ pactVerifier
 	.Verify();
 ```
 
+#### Further Documentation
+
+* [PactNet Workshop using .NET Core](https://github.com/tdshipley/pact-workshop-dotnet-core-v1)
+
 #### Related Tools
 You might also find the following tool and library helpful:
 


### PR DESCRIPTION
Hi @neilcampbell - I recently gave this PactNet workshop at my work and it seemed to go down pretty well and any minor bits in the write up have been caught now. This PR adds a link to the Readme file to the workshop.

Related Issue: https://github.com/pact-foundation/pact-net/issues/133