### PR TITLE
Make properties in PactUriOptions public

### DIFF
--- a/PactNet/PactUriOptions.cs
+++ b/PactNet/PactUriOptions.cs
@@ -7,10 +7,10 @@ namespace PactNet
     {
         private const string AuthScheme = "Basic";
 
-        internal string Username { get; }
-        internal string Password { get; }
-        internal string AuthorizationScheme => AuthScheme;
-        internal string AuthorizationValue => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
+        public string Username { get; }
+        public string Password { get; }
+        public string AuthorizationScheme => AuthScheme;
+        public string AuthorizationValue => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
 
         public PactUriOptions(string username, string password)
         {


### PR DESCRIPTION
This PR makes all properties in PactUriOptions class public. They are readonly properties, so there is no harm done in any case.
It adds a little more comfort working with pact. In my case I have to make a REST call to Pact broker right before verifying pacts in provider to get all pacts for the current provider. For this request I need the same kind of information as for verification: username, password. I think it's more convenient to use same code (class PactUriOptions) in both places and also not to write my own code for creating Basic-authorization value since it's already there