### PR TITLE
Fix GetPactFilePath method in MessagePactBuilder and update unit tests

### DIFF
--- a/PactNet.Tests/Builders/MessagePactBuilderTests.cs
+++ b/PactNet.Tests/Builders/MessagePactBuilderTests.cs
@@ -162,7 +162,7 @@ namespace PactNet.Tests.Builders
             };
 
             pactMessage.MessageInteractions.Returns(expectedInteractions);
-            fileWrapper.Exists(@"..\Test\Test_consumer-Test_provider.json").Returns(true);
+            fileWrapper.Exists(@"..\Test\test_consumer-test_provider.json").Returns(true);
 
             var pactConfig = new PactConfig
             {
@@ -179,7 +179,7 @@ namespace PactNet.Tests.Builders
             pactBuilder.Build();
 
             //Assert
-            fileWrapper.Received().Delete(@"..\Test\Test_consumer-Test_provider.json");
+            fileWrapper.Received().Delete(@"..\Test\test_consumer-test_provider.json");
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace PactNet.Tests.Builders
             };
 
             pactMessage.MessageInteractions.Returns(expectedInteractions);
-            fileWrapper.Exists(@"..\Test\Test_consumer-Test_provider.json").Returns(false);
+            fileWrapper.Exists(@"..\Test\test_consumer-test_provider.json").Returns(false);
 
             var pactConfig = new PactConfig
             {
@@ -223,7 +223,7 @@ namespace PactNet.Tests.Builders
             pactBuilder.Build();
 
             //Assert
-            fileWrapper.DidNotReceive().Delete(@"..\Test\Test_consumer-Test_provider.json");
+            fileWrapper.DidNotReceive().Delete(@"..\Test\test_consumer-test_provider.json");
         }
     }
 }

--- a/PactNet/Builders/MessagePactBuilder.cs
+++ b/PactNet/Builders/MessagePactBuilder.cs
@@ -97,7 +97,7 @@ namespace PactNet
         }
         private static string GetPactFilePath(string pactDir, string consumerName, string producerName)
         {
-            var filePath = $"{pactDir}{consumerName.Replace(" ", "_")}-{producerName.Replace(" ", "_")}.json";
+            var filePath = $"{pactDir}{consumerName.Replace(" ", "_").ToLower()}-{producerName.Replace(" ", "_").ToLower()}.json";
             return filePath;
         }
 


### PR DESCRIPTION
Fix method that identifies previously created pact json file.