### PR TITLE
added handling of cors by mock provider

### DIFF
--- a/PactNet.Tests/Core/MockProviderHostConfigTests.cs
+++ b/PactNet.Tests/Core/MockProviderHostConfigTests.cs
@@ -151,6 +151,24 @@ namespace PactNet.Tests.Core
             Assert.Equal(false, config.WaitForExit);
         }
 
+        [Fact]
+        public void Ctor_WhenCalledWithEnabledCors_SetsTheCorrectArgs()
+        {
+            var port = 9332;
+            var pactConfig = new PactConfig { EnableCors = true };
+            var consumerName = "Cons";
+            var providerName = "The best one";
+
+            var config = GetSubject(port, false, consumerName, providerName, pactConfig);
+
+            var expectedLogFilePath = BuildExpectedLogFilePath(pactConfig.LogDir, providerName);
+            var expectedPactDir = BuildExpectedPactDir(pactConfig.PactDir);
+            var expectedArguments = BuildExpectedArguments(port, expectedLogFilePath, expectedPactDir,
+                pactConfig.SpecificationVersion, consumerName, providerName, false, enableCors: true);
+
+            Assert.Equal(expectedArguments, config.Arguments);
+        }
+
         private string BuildExpectedLogFilePath(string logDir, string providerName)
         {
             return ($"{logDir}{providerName.ToLowerSnakeCase()}_mock_service.log").Replace("\\", "/");
@@ -176,20 +194,21 @@ namespace PactNet.Tests.Core
             bool enableSsl = false,
             IPAddress host = IPAddress.Loopback,
             string sslCert = "",
-            string sslKey = ""
+            string sslKey = "",
+            bool enableCors = false
         )
         {
             var sslOption = enableSsl ? " --ssl" : "";
             var hostOption = host == IPAddress.Any ? " --host=0.0.0.0" : "";
             var sslCertOption = !string.IsNullOrEmpty(sslCert) ? $" --sslcert=\"{sslCert}\"" : string.Empty;
             var sslKeyOption = !string.IsNullOrEmpty(sslKey) ? $" --sslkey=\"{sslKey}\"" : string.Empty;
-
+            var corsOption = enableCors ? " --cors" : string.Empty;
             return
                 $"-p {port} -l \"{logFilePath}\" " +
                 $"--pact-dir \"{pactFileDir}\" " +
                 $"--pact-specification-version \"{pactSpecificationVersion}\" " +
                 $"--consumer \"{consumerName}\" " +
-                $"--provider \"{providerName}\"{sslOption}{hostOption}{sslCertOption}{sslKeyOption}";
+                $"--provider \"{providerName}\"{sslOption}{hostOption}{sslCertOption}{sslKeyOption}{corsOption}";
         }
     }
 }

--- a/PactNet/Core/MockProviderHostConfig.cs
+++ b/PactNet/Core/MockProviderHostConfig.cs
@@ -30,13 +30,15 @@ namespace PactNet.Core
                 ? $" --monkeypatch=\"${config.MonkeyPatchFile}\""
                 : string.Empty;
 
+            var corsOption = config.EnableCors ? " --cors" : string.Empty;
+
             Script = "pact-mock-service";
             Arguments = $"-p {port} -l \"{FixPathForRuby(logFile)}\" --pact-dir \"{FixPathForRuby(config.PactDir)}\" --pact-specification-version \"{config.SpecificationVersion}\" --consumer \"{consumerName}\" --provider \"{providerName}\"{sslOption}{hostOption}{monkeyPatchOption}";
             Arguments = $"-p {port} -l \"{FixPathForRuby(logFile)}\" " +
                         $"--pact-dir \"{FixPathForRuby(config.PactDir)}\" " +
                         $"--pact-specification-version \"{config.SpecificationVersion}\" " +
                         $"--consumer \"{consumerName}\" " +
-                        $"--provider \"{providerName}\"{sslOption}{hostOption}{sslCertOption}{sslKeyOption}{monkeyPatchOption}";
+                        $"--provider \"{providerName}\"{sslOption}{hostOption}{sslCertOption}{sslKeyOption}{monkeyPatchOption}{corsOption}";
 
             WaitForExit = false;
             Outputters = config?.Outputters;

--- a/PactNet/PactConfig.cs
+++ b/PactNet/PactConfig.cs
@@ -27,6 +27,7 @@ namespace PactNet
         internal string LoggerName;
 
         public string MonkeyPatchFile { get; set; }
+        public bool EnableCors { get; set; }
 
         public PactConfig()
         {


### PR DESCRIPTION
in favor to support following functionality and have clear contract: https://github.com/pact-foundation/pact-mock_service/wiki/Using-the-mock-service-with-CORS