### PR TITLE
Fix: await async calls in tests and README, and always use string as a type

### DIFF
--- a/PactNet.Tests/Fakes/FakeHttpMessageHandler.cs
+++ b/PactNet.Tests/Fakes/FakeHttpMessageHandler.cs
@@ -31,18 +31,15 @@ namespace PactNet.Tests.Fakes
             _requestContentReceived = new List<string>();
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             _requestsReceived.Add(request);
             if (request.Content != null)
             {
-                _requestContentReceived.Add(request.Content.ReadAsStringAsync().Result);
+                _requestContentReceived.Add(await request.Content.ReadAsStringAsync());
             }
 
-            var tcs = new TaskCompletionSource<HttpResponseMessage>();
-            tcs.SetResult(ResponseFactory());
-
-            return tcs.Task;
+            return ResponseFactory();
         }
     }
 }

--- a/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
@@ -74,7 +74,7 @@ namespace PactNet.Tests.IntegrationTests
 
             if (response1.StatusCode != HttpStatusCode.OK || response2.StatusCode != HttpStatusCode.OK)
             {
-                throw new Exception(String.Format("Wrong status code '{0} and {1}' was returned", response1.StatusCode, response2.StatusCode));
+                throw new Exception(string.Format("Wrong status code '{0} and {1}' was returned", response1.StatusCode, response2.StatusCode));
             }
 
             _mockProviderService.VerifyInteractions();
@@ -108,7 +108,7 @@ namespace PactNet.Tests.IntegrationTests
 
             if (response.StatusCode != HttpStatusCode.InternalServerError)
             {
-                throw new Exception(String.Format("Wrong status code '{0}' was returned", response.StatusCode));
+                throw new Exception(string.Format("Wrong status code '{0}' was returned", response.StatusCode));
             }
 
             Assert.Throws<PactFailureException>(() => _mockProviderService.VerifyInteractions());

--- a/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace PactNet.Tests.IntegrationTests
@@ -49,7 +50,7 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         [Fact]
-        public void WhenRegisteringAnInteractionThatIsSentMultipleTimes_ThenNoExceptionIsThrown()
+        public async Task WhenRegisteringAnInteractionThatIsSentMultipleTimes_ThenNoExceptionIsThrown()
         {
             _mockProviderService
                 .UponReceiving("A GET request to retrieve a thing")
@@ -68,8 +69,8 @@ namespace PactNet.Tests.IntegrationTests
             var request1 = new HttpRequestMessage(HttpMethod.Get, "/things/1234");
             var request2 = new HttpRequestMessage(HttpMethod.Get, "/things/1234");
 
-            var response1 = httpClient.SendAsync(request1).Result;
-            var response2 = httpClient.SendAsync(request2).Result;
+            var response1 = await httpClient.SendAsync(request1);
+            var response2 = await httpClient.SendAsync(request2);
 
             if (response1.StatusCode != HttpStatusCode.OK || response2.StatusCode != HttpStatusCode.OK)
             {
@@ -80,7 +81,7 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         [Fact]
-        public void WhenRegisteringAnInteractionWhereTheRequestDoesNotExactlyMatchTheActualRequest_ThenStatusCodeReturnedIs500AndPactFailureExceptionIsThrown()
+        public async Task WhenRegisteringAnInteractionWhereTheRequestDoesNotExactlyMatchTheActualRequest_ThenStatusCodeReturnedIs500AndPactFailureExceptionIsThrown()
         {
             _mockProviderService
                 .UponReceiving("A GET request to retrieve things by type")
@@ -103,7 +104,7 @@ namespace PactNet.Tests.IntegrationTests
 
             var request = new HttpRequestMessage(HttpMethod.Get, "/things?type=awesome");
 
-            var response = httpClient.SendAsync(request).Result;
+            var response = await httpClient.SendAsync(request);
 
             if (response.StatusCode != HttpStatusCode.InternalServerError)
             {

--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
@@ -39,7 +39,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         public void Ctor_WhenCalledWithPort_SetsBaseUri()
         {
             const int port = 999;
-            var expectedBaseUri = String.Format("http://localhost:{0}", port);
+            var expectedBaseUri = string.Format("http://localhost:{0}", port);
             var mockService = GetSubject(port);
 
             Assert.Equal(expectedBaseUri, ((MockProviderService)mockService).BaseUri.OriginalString);
@@ -92,7 +92,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         {
             var mockService = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => mockService.Given(String.Empty));
+            Assert.Throws<ArgumentException>(() => mockService.Given(string.Empty));
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         {
             var mockService = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => mockService.UponReceiving(String.Empty));
+            Assert.Throws<ArgumentException>(() => mockService.UponReceiving(string.Empty));
         }
 
         [Fact]
@@ -376,7 +376,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
 
             mockService.VerifyInteractions();
 
-            var testContext = String.Empty;
+            var testContext = string.Empty;
 #if USE_NET4X
             testContext = "MockProviderServiceTests.VerifyInteractions_WhenHostIsNotNull_PerformsAdminInteractionsVerificationGetRequest";
 # endif
@@ -417,7 +417,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
 
             mockService.ClearInteractions();
 
-            var testContext = String.Empty;
+            var testContext = string.Empty;
 #if USE_NET4X
             testContext = "MockProviderServiceTests.ClearInteractions_WhenHostIsNotNull_PerformsAdminInteractionsDeleteRequest";
 # endif

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -40,7 +40,7 @@ namespace PactNet.Tests
         {
             var pactBuilder = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(string.Empty));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace PactNet.Tests
         {
             var pactBuilder = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(string.Empty));
         }
 
         [Fact]

--- a/PactNet.Tests/PactPublisherTests.cs
+++ b/PactNet.Tests/PactPublisherTests.cs
@@ -41,7 +41,7 @@ namespace PactNet.Tests
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(String.Empty, "1.0.0"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(string.Empty, "1.0.0"));
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace PactNet.Tests
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, String.Empty));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, string.Empty));
         }
 
         [Fact]

--- a/PactNet.Tests/PactPublisherTests.cs
+++ b/PactNet.Tests/PactPublisherTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Newtonsoft.Json;
 using PactNet.Models;
 using PactNet.Tests.Fakes;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace PactNet.Tests
@@ -28,45 +29,45 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void PublishToBroker_WithNullPactFileUri_ThrowArgumentNullException()
+        public async Task PublishToBroker_WithNullPactFileUri_ThrowArgumentNullException()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            Assert.Throws<ArgumentNullException>(() => pactPublisher.PublishToBroker(null, "1.0.0"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(null, "1.0.0"));
         }
 
         [Fact]
-        public void PublishToBroker_WithEmptyPactFileUri_ThrowArgumentNullException()
+        public async Task PublishToBroker_WithEmptyPactFileUri_ThrowArgumentNullException()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            Assert.Throws<ArgumentNullException>(() => pactPublisher.PublishToBroker(String.Empty, "1.0.0"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(String.Empty, "1.0.0"));
         }
 
         [Fact]
-        public void PublishToBroker_WithNullConsumerVersion_ThrowArgumentNullException()
+        public async Task PublishToBroker_WithNullConsumerVersion_ThrowArgumentNullException()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            Assert.Throws<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, null));
         }
 
         [Fact]
-        public void PublishToBroker_WithEmptyConsumerVersion_ThrowArgumentNullException()
+        public async Task PublishToBroker_WithEmptyConsumerVersion_ThrowArgumentNullException()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
 
-            Assert.Throws<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, String.Empty));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pactPublisher.PublishToBroker(PactFilePath, String.Empty));
         }
 
         [Fact]
-        public void PublishToBroker_WithNoAuthentication_PublishesPact()
+        public async Task PublishToBroker_WithNoAuthentication_PublishesPact()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttp);
             var pactFileText = File.ReadAllText(PactFilePath);
             var pactDetails = JsonConvert.DeserializeObject<PactDetails>(pactFileText);
 
-            pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
+            await pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
 
             var requestsReceived = _fakeHttpMessageHandler.RequestsReceived;
             Assert.Equal(1, requestsReceived.Count());
@@ -74,13 +75,13 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void PublishToBroker_WithAuthentication_PublishesPact()
+        public async Task PublishToBroker_WithAuthentication_PublishesPact()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttps, AuthOptions);
             var pactFileText = File.ReadAllText(PactFilePath);
             var pactDetails = JsonConvert.DeserializeObject<PactDetails>(pactFileText);
 
-            pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
+            await pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
 
             var requestsReceived = _fakeHttpMessageHandler.RequestsReceived;
             Assert.Equal(1, requestsReceived.Count());
@@ -88,13 +89,13 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void PublishToBroker_WhenCalledWithoutTags_PublishesPactWithoutTags()
+        public async Task PublishToBroker_WhenCalledWithoutTags_PublishesPactWithoutTags()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttps);
             var pactFileText = File.ReadAllText(PactFilePath);
             var pactDetails = JsonConvert.DeserializeObject<PactDetails>(pactFileText);
 
-            pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
+            await pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion);
 
             var requestsReceived = _fakeHttpMessageHandler.RequestsReceived;
             Assert.Equal(1, requestsReceived.Count());
@@ -102,14 +103,14 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void PublishToBroker_WhenCalledWithTags_PublishesPactWithTags()
+        public async Task PublishToBroker_WhenCalledWithTags_PublishesPactWithTags()
         {
             var pactPublisher = GetSubject(BrokerBaseUriHttps, AuthOptions);
             var pactFileText = File.ReadAllText(PactFilePath);
             var tags = new[] { "master", "something-else" };
             var pactDetails = JsonConvert.DeserializeObject<PactDetails>(pactFileText);
 
-            pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion, tags);
+            await pactPublisher.PublishToBroker(PactFilePath, ConsumerVersion, tags);
 
             var requestsReceived = _fakeHttpMessageHandler.RequestsReceived;
             Assert.Equal(3, requestsReceived.Count());

--- a/PactNet.Tests/PactVerifierTests.cs
+++ b/PactNet.Tests/PactVerifierTests.cs
@@ -58,7 +58,7 @@ namespace PactNet.Tests
 
             Assert.Throws<ArgumentException>(() =>
                 pactVerifier
-                .ProviderState(String.Empty));
+                .ProviderState(string.Empty));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider(String.Empty, "http://localhost:3442"));
+            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider(string.Empty, "http://localhost:3442"));
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.HonoursPactWith(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactVerifier.HonoursPactWith(string.Empty));
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.PactUri(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactVerifier.PactUri(string.Empty));
         }
 
         [Fact]

--- a/PactNet/Core/PactCoreHost.cs
+++ b/PactNet/Core/PactCoreHost.cs
@@ -17,7 +17,7 @@ namespace PactNet.Core
         {
             _config = config;
 
-            var expectedPackage = String.Empty;
+            var expectedPackage = string.Empty;
 
 #if USE_NET4X
             var pactCoreDir = $"{Constants.BuildDirectory}{Path.DirectorySeparatorChar}"; //OS specific version will be appended
@@ -193,9 +193,9 @@ namespace PactNet.Core
 
         private string ReplaceConfigParams(string input, string pactCoreDir, string script)
         {
-            return !String.IsNullOrEmpty(input) ?
+            return !string.IsNullOrEmpty(input) ?
                 input.Replace("{pactCoreDir}", pactCoreDir).Replace("{script}", script) :
-                String.Empty;
+                string.Empty;
         }
     }
 }

--- a/PactNet/Core/PactVerifierHostConfig.cs
+++ b/PactNet/Core/PactVerifierHostConfig.cs
@@ -20,7 +20,7 @@ namespace PactNet.Core
             var providerStateOption = providerStateSetupUri != null ? $" --provider-states-setup-url \"{providerStateSetupUri.OriginalString}\"" : string.Empty;
             var pactBrokerOptions = BuildPactBrokerOptions(brokerConfig);
             var brokerCredentials = pactBrokerUriOptions != null ?
-                !String.IsNullOrEmpty(pactBrokerUriOptions.Username) && !String.IsNullOrEmpty(pactBrokerUriOptions.Password) ? 
+                !string.IsNullOrEmpty(pactBrokerUriOptions.Username) && !string.IsNullOrEmpty(pactBrokerUriOptions.Password) ? 
                     $" --broker-username \"{pactBrokerUriOptions.Username}\" --broker-password \"{pactBrokerUriOptions.Password}\"" : 
                     $" --broker-token \"{pactBrokerUriOptions.Token}\""
                  : string.Empty;
@@ -74,7 +74,7 @@ namespace PactNet.Core
             var providerVersionTags = BuildTags("provider-version-tag", config.ProviderVersionTags);
             var consumerVersionSelectors = BuildTags("consumer-version-selector", config.ConsumerVersionSelectors);
             var enablePending = config.EnablePending ? " --enable-pending" : "";
-            var includeWipPactsSince = !String.IsNullOrEmpty(config.IncludeWipPactsSince) ? $" --include-wip-pacts-since \"{config.IncludeWipPactsSince}\"" : string.Empty;
+            var includeWipPactsSince = !string.IsNullOrEmpty(config.IncludeWipPactsSince) ? $" --include-wip-pacts-since \"{config.IncludeWipPactsSince}\"" : string.Empty;
 
             return $" --pact-broker-base-url \"{config.BrokerBaseUri}\" --provider \"{config.ProviderName}\"{consumerVersionTags}{providerVersionTags}{consumerVersionSelectors}{enablePending}{includeWipPactsSince}";
         }

--- a/PactNet/Extensions/StringExtensions.cs
+++ b/PactNet/Extensions/StringExtensions.cs
@@ -1,14 +1,12 @@
-using System;
-
 namespace PactNet.Extensions
 {
     public static class StringExtensions
     {
         public static string ToLowerSnakeCase(this string input)
         {
-            return !String.IsNullOrEmpty(input) ?
+            return !string.IsNullOrEmpty(input) ?
                 input.Replace(' ', '_').ToLower() :
-                String.Empty;
+                string.Empty;
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/Mappers/HttpMethodMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/HttpMethodMapper.cs
@@ -22,7 +22,7 @@ namespace PactNet.Mocks.MockHttpService.Mappers
         {
             if (!Map.ContainsKey(from))
             {
-                throw new ArgumentException(String.Format("Cannot map HttpVerb.{0} to a HttpMethod, no matching item has been registered.", from));
+                throw new ArgumentException(string.Format("Cannot map HttpVerb.{0} to a HttpMethod, no matching item has been registered.", from));
             }
 
             return Map[from];

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -253,7 +253,7 @@ namespace PactNet.Mocks.MockHttpService
             return Join(" ", relevantStackFrameSummaries);
 
 #else
-            return String.Empty;
+            return string.Empty;
 #endif
         }
     }

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -38,7 +38,7 @@ namespace PactNet
 
         public IPactBuilder ServiceConsumer(string consumerName)
         {
-            if (String.IsNullOrEmpty(consumerName))
+            if (string.IsNullOrEmpty(consumerName))
             {
                 throw new ArgumentException("Please supply a non null or empty consumerName");
             }
@@ -50,7 +50,7 @@ namespace PactNet
 
         public IPactBuilder HasPactWith(string providerName)
         {
-            if (String.IsNullOrEmpty(providerName))
+            if (string.IsNullOrEmpty(providerName))
             {
                 throw new ArgumentException("Please supply a non null or empty providerName");
             }
@@ -78,13 +78,13 @@ namespace PactNet
             string sslCert = null, 
             string sslKey = null)
         {
-            if (String.IsNullOrEmpty(ConsumerName))
+            if (string.IsNullOrEmpty(ConsumerName))
             {
                 throw new InvalidOperationException(
                     "ConsumerName has not been set, please supply a consumer name using the ServiceConsumer method.");
             }
 
-            if (String.IsNullOrEmpty(ProviderName))
+            if (string.IsNullOrEmpty(ProviderName))
             {
                 throw new InvalidOperationException(
                     "ProviderName has not been set, please supply a provider name using the HasPactWith method.");

--- a/PactNet/PactPublisher.cs
+++ b/PactNet/PactPublisher.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
 using PactNet.Models;
+using System.Threading.Tasks;
 
 namespace PactNet
 {
@@ -30,7 +31,7 @@ namespace PactNet
         {
         }
 
-        public void PublishToBroker(string pactFileUri, string consumerVersion, IEnumerable<string> tags = null)
+        public async Task PublishToBroker(string pactFileUri, string consumerVersion, IEnumerable<string> tags = null)
         {
             if (String.IsNullOrEmpty(pactFileUri))
             {
@@ -57,13 +58,13 @@ namespace PactNet
                         tagRequest.Headers.Add("Authorization", $"{_brokerUriOptions.AuthorizationScheme} {_brokerUriOptions.AuthorizationValue}");
                     }
 
-                    var tagResponse = _httpClient.SendAsync(tagRequest, CancellationToken.None).Result;
+                    var tagResponse = await _httpClient.SendAsync(tagRequest, CancellationToken.None);
                     var tagResponseStatusCode = tagResponse.StatusCode;
                     var tagResponseContent = String.Empty;
 
                     if (tagResponse.Content != null)
                     {
-                        tagResponseContent = tagResponse.Content.ReadAsStringAsync().Result;
+                        tagResponseContent = await tagResponse.Content.ReadAsStringAsync();
                     }
 
                     Dispose(tagRequest);
@@ -85,13 +86,13 @@ namespace PactNet
 
             request.Content = new StringContent(pactFileText, Encoding.UTF8, "application/json");
 
-            var response = _httpClient.SendAsync(request, CancellationToken.None).Result;
+            var response = await _httpClient.SendAsync(request, CancellationToken.None);
             var responseStatusCode = response.StatusCode;
             var responseContent = String.Empty;
 
             if (response.Content != null)
             {
-                responseContent = response.Content.ReadAsStringAsync().Result;
+                responseContent = await response.Content.ReadAsStringAsync();
             }
 
             Dispose(request);

--- a/PactNet/PactPublisher.cs
+++ b/PactNet/PactPublisher.cs
@@ -33,12 +33,12 @@ namespace PactNet
 
         public async Task PublishToBroker(string pactFileUri, string consumerVersion, IEnumerable<string> tags = null)
         {
-            if (String.IsNullOrEmpty(pactFileUri))
+            if (string.IsNullOrEmpty(pactFileUri))
             {
                 throw new ArgumentNullException("pactFileUri is null or empty");
             }
 
-            if (String.IsNullOrEmpty(consumerVersion))
+            if (string.IsNullOrEmpty(consumerVersion))
             {
                 throw new ArgumentNullException("consumerVersion is null or empty");
             }
@@ -60,7 +60,7 @@ namespace PactNet
 
                     var tagResponse = await _httpClient.SendAsync(tagRequest, CancellationToken.None);
                     var tagResponseStatusCode = tagResponse.StatusCode;
-                    var tagResponseContent = String.Empty;
+                    var tagResponseContent = string.Empty;
 
                     if (tagResponse.Content != null)
                     {
@@ -88,7 +88,7 @@ namespace PactNet
 
             var response = await _httpClient.SendAsync(request, CancellationToken.None);
             var responseStatusCode = response.StatusCode;
-            var responseContent = String.Empty;
+            var responseContent = string.Empty;
 
             if (response.Content != null)
             {

--- a/PactNet/PactUriOptions.cs
+++ b/PactNet/PactUriOptions.cs
@@ -13,7 +13,7 @@ namespace PactNet
 
         public PactUriOptions(string username, string password)
         {
-            if (String.IsNullOrEmpty(username))
+            if (string.IsNullOrEmpty(username))
             {
                 throw new ArgumentException("username is null or empty.");
             }
@@ -23,7 +23,7 @@ namespace PactNet
                 throw new ArgumentException("username contains a ':' character, which is not allowed.");
             }
 
-            if (String.IsNullOrEmpty(password))
+            if (string.IsNullOrEmpty(password))
             {
                 throw new ArgumentException("password is null or empty.");
             }
@@ -36,7 +36,7 @@ namespace PactNet
 
         public PactUriOptions(string token)
         {
-            if (String.IsNullOrEmpty(token))
+            if (string.IsNullOrEmpty(token))
             {
                 throw new ArgumentException("token is null or empty.");
             }

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ public class SomethingApiClient
     _client = new HttpClient { BaseAddress = new Uri(baseUri ?? "http://my-api") };
   }
 
-  public Something GetSomething(string id)
+  public async Task<Something> GetSomething(string id)
   {
     string reasonPhrase;
 
     var request = new HttpRequestMessage(HttpMethod.Get, "/somethings/" + id);
     request.Headers.Add("Accept", "application/json");
 
-    var response = _client.SendAsync(request);
+    var response = await _client.SendAsync(request);
 
-    var content = response.Result.Content.ReadAsStringAsync().Result;
-    var status = response.Result.StatusCode;
+    var content = await response.Content.ReadAsStringAsync();
+    var status = response.StatusCode;
 
-    reasonPhrase = response.Result.ReasonPhrase; //NOTE: any Pact mock provider errors will be returned here and in the response body
+    reasonPhrase = response.ReasonPhrase; //NOTE: any Pact mock provider errors will be returned here and in the response body
 
     request.Dispose();
     response.Dispose();

--- a/README_v1.md
+++ b/README_v1.md
@@ -40,7 +40,7 @@ public class SomethingApiClient
 		BaseUri = baseUri ?? "http://my-api";
 	}
 	
-	public Something GetSomething(string id)
+	public async Task<Something> GetSomething(string id)
 	{
 		string reasonPhrase;
 		
@@ -49,12 +49,12 @@ public class SomethingApiClient
 			var request = new HttpRequestMessage(HttpMethod.Get, "/somethings/" + id);
 			request.Headers.Add("Accept", "application/json");
 
-			var response = client.SendAsync(request);
+			var response = await client.SendAsync(request);
 
-			var content = response.Result.Content.ReadAsStringAsync().Result;
-			var status = response.Result.StatusCode;
+			var content = await response.Content.ReadAsStringAsync();
+			var status = response.StatusCode;
 
-			reasonPhrase = response.Result.ReasonPhrase; //NOTE: any Pact mock provider errors will be returned here and in the response body
+			reasonPhrase = response.ReasonPhrase; //NOTE: any Pact mock provider errors will be returned here and in the response body
 			
 			request.Dispose();
 			response.Dispose();

--- a/Samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/Samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -265,8 +265,8 @@ namespace Consumer.Tests
             var eventId = Guid.Parse("83F9262F-28F1-4703-AB1A-8CFD9E8249C9");
             var eventType = "DetailsView";
             var eventTimestamp = DateTime.UtcNow;
-            _mockProviderService.Given(String.Format("there is an event with id '{0}'", eventId))
-                .UponReceiving(String.Format("a request to retrieve event with id '{0}'", eventId))
+            _mockProviderService.Given(string.Format("there is an event with id '{0}'", eventId))
+                .UponReceiving(string.Format("a request to retrieve event with id '{0}'", eventId))
                 .With(new ProviderServiceRequest
                 {
                     Method = HttpVerb.Get,
@@ -310,8 +310,8 @@ namespace Consumer.Tests
         {
             //Arrange
             const string eventType = "DetailsView";
-            _mockProviderService.Given(String.Format("there is one event with type '{0}'", eventType))
-                .UponReceiving(String.Format("a request to retrieve events with type '{0}'", eventType))
+            _mockProviderService.Given(string.Format("there is one event with type '{0}'", eventType))
+                .UponReceiving(string.Format("a request to retrieve events with type '{0}'", eventType))
                 .With(new ProviderServiceRequest
                 {
                     Method = HttpVerb.Get,

--- a/Samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/Samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using PactNet.Matchers;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Consumer.Tests
@@ -21,7 +22,7 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void GetAllEvents_WithNoAuthorizationToken_ShouldFail()
+        public async Task GetAllEvents_WithNoAuthorizationToken_ShouldFail()
         {
             //Arrange
             _mockProviderService.Given("there are events with ids '45D80D13-D5A2-48D7-8353-CBB4C0EAABF5', '83F9262F-28F1-4703-AB1A-8CFD9E8249C9' and '3E83A96B-2A0C-49B1-9959-26DF23F83AEB'")
@@ -49,15 +50,15 @@ namespace Consumer.Tests
                 });
 
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
-
+            
             //Act //Assert
-            Assert.ThrowsAny<Exception>(() => consumer.GetAllEvents());
+            await Assert.ThrowsAnyAsync<Exception>(() => consumer.GetAllEvents());
             
             _mockProviderService.VerifyInteractions();
         }
 
         [Fact]
-        public void GetAllEvents_WhenCalled_ReturnsAllEvents()
+        public async Task GetAllEvents_WhenCalled_ReturnsAllEvents()
         {
             var test = new[]
             {
@@ -111,7 +112,7 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri, testAuthToken);
 
             //Act
-            var events = consumer.GetAllEvents();
+            var events = await consumer.GetAllEvents();
 
             //Assert
             Assert.NotEmpty(events);
@@ -122,7 +123,7 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void CreateEvent_WhenCalledWithEvent_Succeeds()
+        public async Task CreateEvent_WhenCalledWithEvent_Succeeds()
         {
             //Arrange
             var eventId = Guid.Parse("1F587704-2DCC-4313-A233-7B62B4B469DB");
@@ -153,13 +154,13 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
 
             //Act / Assert
-            consumer.CreateEvent(eventId);
+            await consumer.CreateEvent(eventId);
 
             _mockProviderService.VerifyInteractions();
         }
 
         [Fact]
-        public void IsAlive_WhenApiIsAlive_ReturnsTrue()
+        public async Task IsAlive_WhenApiIsAlive_ReturnsTrue()
         {
             //Arrange
             _mockProviderService.UponReceiving("a request to check the api status")
@@ -189,7 +190,7 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
 
             //Act
-            var result = consumer.IsAlive();
+            var result = await consumer.IsAlive();
 
             //Assert
             Assert.Equal(true, result);
@@ -198,7 +199,7 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void UpSince_WhenApiIsAliveAndWeRetrieveUptime_ReturnsUpSinceDate()
+        public async Task UpSince_WhenApiIsAliveAndWeRetrieveUptime_ReturnsUpSinceDate()
         {
             //Arrange
             var upSinceDate = new DateTime(2014, 6, 27, 23, 51, 12, DateTimeKind.Utc);
@@ -248,7 +249,7 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
 
             //Act
-            var result = consumer.UpSince();
+            var result = await consumer.UpSince();
 
             //Assert
             Assert.Equal(upSinceDate.ToString("O"), result.Value.ToString("O"));
@@ -257,7 +258,7 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void GetEventById_WhenTheEventExists_ReturnsEvent()
+        public async Task GetEventById_WhenTheEventExists_ReturnsEvent()
         {
             //Arrange
             var guidRegex = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
@@ -294,7 +295,7 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
 
             //Act
-            var result = consumer.GetEventById(eventId);
+            var result = await consumer.GetEventById(eventId);
 
             //Assert
             Assert.Equal(eventId, result.EventId);
@@ -305,7 +306,7 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void GetEventsByType_WhenOneEventWithTheTypeExists_ReturnsEvent()
+        public async Task GetEventsByType_WhenOneEventWithTheTypeExists_ReturnsEvent()
         {
             //Arrange
             const string eventType = "DetailsView";
@@ -340,7 +341,7 @@ namespace Consumer.Tests
             var consumer = new EventsApiClient(_mockProviderServiceBaseUri);
 
             //Act
-            var result = consumer.GetEventsByType(eventType);
+            var result = await consumer.GetEventsByType(eventType);
 
             //Assert
             Assert.Equal(eventType, result.First().EventType);

--- a/Samples/EventApi/Consumer/EventsApiClient.cs
+++ b/Samples/EventApi/Consumer/EventsApiClient.cs
@@ -80,7 +80,7 @@ namespace Consumer
                 {
                     var uptimeLink = statusResponseBody.Links.Single(x => x.Key.Equals("uptime")).Value.Href;
 
-                    if (!String.IsNullOrEmpty(uptimeLink))
+                    if (!string.IsNullOrEmpty(uptimeLink))
                     {
                         var uptimeRequest = new HttpRequestMessage(HttpMethod.Get, uptimeLink);
                         uptimeRequest.Headers.Add("Accept", "application/json");
@@ -123,7 +123,7 @@ namespace Consumer
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     var content = await response.Content.ReadAsStringAsync();
-                    return !String.IsNullOrEmpty(content)
+                    return !string.IsNullOrEmpty(content)
                                 ? JsonConvert.DeserializeObject<IEnumerable<Event>>(content, _jsonSettings)
                                 : new List<Event>();
                 }
@@ -140,7 +140,7 @@ namespace Consumer
 
         public async Task<Event> GetEventById(Guid id)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, String.Format("/events/{0}", id));
+            var request = new HttpRequestMessage(HttpMethod.Get, string.Format("/events/{0}", id));
             request.Headers.Add("Accept", "application/json");
 
             var response = await _httpClient.SendAsync(request);
@@ -164,7 +164,7 @@ namespace Consumer
 
         public async Task<IEnumerable<Event>> GetEventsByType(string eventType)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, String.Format("/events?type={0}", eventType));
+            var request = new HttpRequestMessage(HttpMethod.Get, string.Format("/events?type={0}", eventType));
             request.Headers.Add("Accept", "application/json");
 
             var response = await _httpClient.SendAsync(request);
@@ -220,7 +220,7 @@ namespace Consumer
         private static async Task RaiseResponseError(HttpRequestMessage failedRequest, HttpResponseMessage failedResponse)
         {
             throw new HttpRequestException(
-                String.Format("The Events API request for {0} {1} failed. Response Status: {2}, Response Body: {3}",
+                string.Format("The Events API request for {0} {1} failed. Response Status: {2}, Response Body: {3}",
                 failedRequest.Method.ToString().ToUpperInvariant(),
                 failedRequest.RequestUri,
                 (int)failedResponse.StatusCode, 

--- a/Samples/EventApi/Consumer/EventsApiClient.cs
+++ b/Samples/EventApi/Consumer/EventsApiClient.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Consumer.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace Consumer
 {
@@ -30,23 +31,22 @@ namespace Consumer
             NullValueHandling = NullValueHandling.Ignore
         };
 
-        public bool IsAlive()
+        public async Task<bool> IsAlive()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "/stats/status");
             request.Headers.Add("Accept", "application/json");
 
-            var response = _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request);
 
             try
             {
-                var result = response.Result;
-                if (result.StatusCode == HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    var responseContent = JsonConvert.DeserializeObject<dynamic>(result.Content.ReadAsStringAsync().Result, _jsonSettings);
+                    var responseContent = JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync(), _jsonSettings);
                     return responseContent.alive;
                 }
 
-                RaiseResponseError(request, result);
+                await RaiseResponseError(request, response);
             }
             finally
             {
@@ -56,25 +56,24 @@ namespace Consumer
             return false;
         }
 
-        public DateTime? UpSince()
+        public async Task<DateTime?> UpSince()
         {
             var statusRequest = new HttpRequestMessage(HttpMethod.Get, "/stats/status");
             statusRequest.Headers.Add("Accept", "application/json");
 
-            var statusResponse = _httpClient.SendAsync(statusRequest);
+            var statusResponse = await _httpClient.SendAsync(statusRequest);
 
             try
             {
-                var statusResult = statusResponse.Result;
                 var statusResponseBody = new StatusResponseBody();
 
-                if (statusResult.StatusCode == HttpStatusCode.OK)
+                if (statusResponse.StatusCode == HttpStatusCode.OK)
                 {
-                    statusResponseBody = JsonConvert.DeserializeObject<StatusResponseBody>(statusResult.Content.ReadAsStringAsync().Result, _jsonSettings);
+                    statusResponseBody = JsonConvert.DeserializeObject<StatusResponseBody>(await statusResponse.Content.ReadAsStringAsync(), _jsonSettings);
                 }
                 else
                 {
-                    RaiseResponseError(statusRequest, statusResult);
+                    await RaiseResponseError(statusRequest, statusResponse);
                 }
 
                 if (statusResponseBody.Alive)
@@ -86,17 +85,16 @@ namespace Consumer
                         var uptimeRequest = new HttpRequestMessage(HttpMethod.Get, uptimeLink);
                         uptimeRequest.Headers.Add("Accept", "application/json");
 
-                        var uptimeResponse = _httpClient.SendAsync(uptimeRequest);
+                        var uptimeResponse = await _httpClient.SendAsync(uptimeRequest);
                         try
                         {
-                            var uptimeResult = uptimeResponse.Result;
-                            if (uptimeResult.StatusCode == HttpStatusCode.OK)
+                            if (uptimeResponse.StatusCode == HttpStatusCode.OK)
                             {
-                                var uptimeResponseBody = JsonConvert.DeserializeObject<UptimeResponseBody>(uptimeResult.Content.ReadAsStringAsync().Result, _jsonSettings);
+                                var uptimeResponseBody = JsonConvert.DeserializeObject<UptimeResponseBody>(await uptimeResponse.Content.ReadAsStringAsync(), _jsonSettings);
                                 return uptimeResponseBody.UpSince;
                             }
 
-                            RaiseResponseError(uptimeRequest, uptimeResult);
+                            await RaiseResponseError(uptimeRequest, uptimeResponse);
                         }
                         finally
                         {
@@ -113,25 +111,24 @@ namespace Consumer
             return null;
         }
 
-        public IEnumerable<Event> GetAllEvents()
+        public async Task<IEnumerable<Event>> GetAllEvents()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "/events");
             request.Headers.Add("Accept", "application/json");
 
-            var response = _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request);
 
             try
             {
-                var result = response.Result;
-                if (result.StatusCode == HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    var content = result.Content.ReadAsStringAsync().Result;
+                    var content = await response.Content.ReadAsStringAsync();
                     return !String.IsNullOrEmpty(content)
                                 ? JsonConvert.DeserializeObject<IEnumerable<Event>>(content, _jsonSettings)
                                 : new List<Event>();
                 }
 
-                RaiseResponseError(request, result);
+                await RaiseResponseError(request, response);
             }
             finally
             {
@@ -141,22 +138,21 @@ namespace Consumer
             return null;
         }
 
-        public Event GetEventById(Guid id)
+        public async Task<Event> GetEventById(Guid id)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, String.Format("/events/{0}", id));
             request.Headers.Add("Accept", "application/json");
 
-            var response = _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request);
 
             try
             {
-                var result = response.Result;
-                if (result.StatusCode == HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    return JsonConvert.DeserializeObject<Event>(result.Content.ReadAsStringAsync().Result, _jsonSettings);
+                    return JsonConvert.DeserializeObject<Event>(await response.Content.ReadAsStringAsync(), _jsonSettings);
                 }
 
-                RaiseResponseError(request, result);
+                await RaiseResponseError(request, response);
             }
             finally
             {
@@ -166,22 +162,21 @@ namespace Consumer
             return null;
         }
 
-        public IEnumerable<Event> GetEventsByType(string eventType)
+        public async Task<IEnumerable<Event>> GetEventsByType(string eventType)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, String.Format("/events?type={0}", eventType));
             request.Headers.Add("Accept", "application/json");
 
-            var response = _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request);
 
             try
             {
-                var result = response.Result;
-                if (result.StatusCode == HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    return JsonConvert.DeserializeObject<IEnumerable<Event>>(result.Content.ReadAsStringAsync().Result, _jsonSettings);
+                    return JsonConvert.DeserializeObject<IEnumerable<Event>>(await response.Content.ReadAsStringAsync(), _jsonSettings);
                 }
 
-                RaiseResponseError(request, result);
+                await RaiseResponseError(request, response);
             }
             finally
             {
@@ -191,7 +186,7 @@ namespace Consumer
             return null;
         }
 
-        public void CreateEvent(Guid eventId, string eventType = "DetailsView")
+        public async Task CreateEvent(Guid eventId, string eventType = "DetailsView")
         {
             var @event = new
             {
@@ -204,18 +199,17 @@ namespace Consumer
             var requestContent = new StringContent(eventJson, Encoding.UTF8, "application/json");
             var request = new HttpRequestMessage(HttpMethod.Post, "/events") { Content = requestContent };
 
-            var response = _httpClient.SendAsync(request);
+            var response = await _httpClient.SendAsync(request);
 
             try
             {
-                var result = response.Result;
-                var statusCode = result.StatusCode;
+                var statusCode = response.StatusCode;
                 if (statusCode == HttpStatusCode.Created)
                 {
                     return;
                 }
 
-                RaiseResponseError(request, result);
+                await RaiseResponseError(request, response);
             }
             finally
             {
@@ -223,14 +217,14 @@ namespace Consumer
             }
         }
 
-        private static void RaiseResponseError(HttpRequestMessage failedRequest, HttpResponseMessage failedResponse)
+        private static async Task RaiseResponseError(HttpRequestMessage failedRequest, HttpResponseMessage failedResponse)
         {
             throw new HttpRequestException(
                 String.Format("The Events API request for {0} {1} failed. Response Status: {2}, Response Body: {3}",
                 failedRequest.Method.ToString().ToUpperInvariant(),
                 failedRequest.RequestUri,
                 (int)failedResponse.StatusCode, 
-                failedResponse.Content.ReadAsStringAsync().Result));
+                await failedResponse.Content.ReadAsStringAsync()));
         }
 
         public void Dispose()


### PR DESCRIPTION
I was taking a look at the project, and I found a few places where async calls were not awaited. This is a practice that [can lead](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#avoid-using-taskresult-and-taskwait) to some problems in C#. We should not `.Result` async calls, as that could lead to deadlocks and is considered a bad practice in C#.

I fixed all the instances in tests and README, to better guide people looking at the repository for samples. I also fixed all references that used `String` as a class instead of `string` as a type, as that is also considered a [bad practice](https://blog.paranoidcoding.com/2019/04/08/string-vs-String-is-not-about-style.html).

I couldn't fix all the `.Result` occurrences though, there is a significant design issue that I think you should be aware and take a look. The [MockProviderService](https://github.com/pact-foundation/pact-net/blob/master/PactNet/Mocks/MockHttpService/MockProviderService.cs) makes async calls to configure the Ruby server. As many documentation on async says, [async is viral](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#asynchrony-is-viral), and it should bubble up all the way (reasons mentioned in the link), so with that in mind, all the `_adminHttpClient.SendAdminHttpRequest` calls should be awaited, which then makes `RegisterInteraction` a method that should be async, which in turn dictates that `WillRespondWith` should also be async. Now, that's the big problem, `WillRespondWith` is a fluent method, so making it async breaks all the API that was designed to work as a fluent syntax.
Keeping the code the way it is today is a big problem, though, because people's code could be deadlocking when using Pact-net and they will have a hard time diagnosing it.

With that in mind, please consider a different way of designing the fluent syntax, or at least take a look at ways of mitigating the deadlock issue described [here](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-deadlocks). Also, just so you know, .NET 5, which is set [to be released in November](https://github.com/dotnet/core/blob/master/roadmap.md), will provide [sync methods](https://github.com/dotnet/runtime/pull/34948) for `HttpClient`, so you could just call `httpClient.Send` instead of `SendAsync`. That would fix all your problems in the `MockProviderService` class, since locking the main thread (beucase of the sync methods) shouldn't be a big deal in test suites.