### PR TITLE
Remote mock server service for consumer tests

### DIFF
--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
@@ -282,7 +282,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         }
 
         [Fact]
-        public void WillRespondWith_WhenHostIsNull_ThrowsInvalidOperationException()
+        public void WillRespondWith_WhenHostIsNull_DoNotThrowsInvalidOperationException()
         {
             var providerState = "My provider state";
             var description = "My description";
@@ -298,8 +298,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
 
             mockService.Stop();
 
-            Assert.Throws<InvalidOperationException>(() => mockService.WillRespondWith(response));
-            Assert.Equal(0, _fakeHttpMessageHandler.RequestsReceived.Count());
+            Assert.Equal(1, _fakeHttpMessageHandler.RequestsReceived.Count());
         }
 
         [Fact]
@@ -398,14 +397,14 @@ namespace PactNet.Tests.Mocks.MockHttpService
         }
 
         [Fact]
-        public void ClearInteractions_WhenHostIsNull_DoesNotPerformAdminInteractionsDeleteRequest()
+        public void ClearInteractions_WhenHostIsNull_CanPerformAdminInteractionsDeleteRequest()
         {
             var mockService = GetSubject();
             mockService.Stop();
 
             mockService.ClearInteractions();
 
-            Assert.Equal(0, _fakeHttpMessageHandler.RequestsReceived.Count());
+            Assert.Equal(2, _fakeHttpMessageHandler.RequestsReceived.Count());
         }
 
         [Fact]

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using NSubstitute;
 using PactNet.Configuration.Json;

--- a/PactNet/IPactBuilder.cs
+++ b/PactNet/IPactBuilder.cs
@@ -8,9 +8,9 @@ namespace PactNet
     {
         IPactBuilder ServiceConsumer(string consumerName);
         IPactBuilder HasPactWith(string providerName);
-        IMockProviderService MockService(int port, bool enableSsl = false, IPAddress host = IPAddress.Loopback, string sslCert = null, string sslKey = null);
+        IMockProviderService MockService(int port, bool enableSsl = false, IPAddress host = IPAddress.Loopback, string sslCert = null, string sslKey = null, bool useRemoteMockService = false);
         IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings,
-            bool enableSsl = false, IPAddress host = IPAddress.Loopback, string sslCert = null, string sslKey = null);
+            bool enableSsl = false, IPAddress host = IPAddress.Loopback, string sslCert = null, string sslKey = null, bool useRemoteMockService = false);
 
         void Build();
     }

--- a/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
+++ b/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,9 +41,9 @@ namespace PactNet.Mocks.MockHttpService
         {
         }
 
-        public async Task SendAdminHttpRequest(HttpVerb method, string path)
+        public async Task SendAdminHttpRequest(HttpVerb method, string path, IDictionary<string, string> headers = null)
         {
-            await SendAdminHttpRequest<object>(method, path, null);
+            await SendAdminHttpRequest<object>(method, path, null, headers:headers);
         }
 
         public async Task SendAdminHttpRequest<T>(HttpVerb method, string path, T requestContent, IDictionary<string, string> headers = null) where T : class
@@ -75,6 +77,7 @@ namespace PactNet.Mocks.MockHttpService
 
             Dispose(request);
             Dispose(response);
+
 
             if (responseStatusCode != HttpStatusCode.OK)
             {

--- a/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
+++ b/PactNet/Mocks/MockHttpService/AdminHttpClient.cs
@@ -78,6 +78,10 @@ namespace PactNet.Mocks.MockHttpService
             Dispose(request);
             Dispose(response);
 
+            if (path == "/pact" && headers != null && headers.ContainsKey("fileNameAndPath"))
+            {
+                File.WriteAllText(headers["fileNameAndPath"], responseContent);
+            }
 
             if (responseStatusCode != HttpStatusCode.OK)
             {

--- a/PactNet/Mocks/MockHttpService/IMockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/IMockProviderService.cs
@@ -12,6 +12,6 @@ namespace PactNet.Mocks.MockHttpService
         void Stop();
         void ClearInteractions();
         void VerifyInteractions();
-        void SendAdminHttpRequest(HttpVerb method, string path);
+        void SendAdminHttpRequest(HttpVerb method, string path, Dictionary<string, string> headers = null);
     }
 }

--- a/PactNet/Mocks/MockHttpService/IMockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/IMockProviderService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService
@@ -5,6 +6,7 @@ namespace PactNet.Mocks.MockHttpService
     public interface IMockProviderService : IMockProvider<IMockProviderService>
     {
         IMockProviderService With(ProviderServiceRequest request);
+        bool UseRemoteMockService { get; set; }
         void WillRespondWith(ProviderServiceResponse response);
         void Start();
         void Stop();

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -127,7 +127,7 @@ namespace PactNet.Mocks.MockHttpService
             Async.RunSync(() => _adminHttpClient.SendAdminHttpRequest(HttpVerb.Get, $"{Constants.InteractionsVerificationPath}?example_description={testContext}"));
         }
 
-        public void SendAdminHttpRequest(HttpVerb method, string path)
+        public void SendAdminHttpRequest(HttpVerb method, string path, Dictionary<string, string> headers = null)
         {
             Async.RunSync(() => _adminHttpClient.SendAdminHttpRequest(method, path));
         }

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -97,6 +97,8 @@ namespace PactNet.Mocks.MockHttpService
             return this;
         }
 
+        public bool UseRemoteMockService { get; set; }
+
         public void WillRespondWith(ProviderServiceResponse response)
         {
             if (response == null)

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -129,7 +129,7 @@ namespace PactNet.Mocks.MockHttpService
 
         public void SendAdminHttpRequest(HttpVerb method, string path, Dictionary<string, string> headers = null)
         {
-            Async.RunSync(() => _adminHttpClient.SendAdminHttpRequest(method, path));
+            Async.RunSync(() => _adminHttpClient.SendAdminHttpRequest(method, path, headers:headers));
         }
 
         public void Start()

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
@@ -10,6 +11,8 @@ namespace PactNet
     {
         public string ConsumerName { get; private set; }
         public string ProviderName { get; private set; }
+
+        private readonly string _pactDir;
 
         private readonly
             Func<int, bool, string, string, IPAddress, JsonSerializerSettings, string, string, IMockProviderService>
@@ -34,6 +37,7 @@ namespace PactNet
                 new MockProviderService(port, enableSsl, consumerName, providerName, config, host,
                     jsonSerializerSettings, sslCert, sslKey))
         {
+            _pactDir = config.PactDir;
         }
 
         public IPactBuilder ServiceConsumer(string consumerName)
@@ -65,9 +69,10 @@ namespace PactNet
             bool enableSsl = false, 
             IPAddress host = IPAddress.Loopback, 
             string sslCert = null, 
-            string sslKey = null)
+            string sslKey = null,
+            bool useRemoteMockService = false)
         {
-            return MockService(port, jsonSerializerSettings: null, enableSsl: enableSsl, host: host, sslCert: sslCert, sslKey: sslKey);
+            return MockService(port, jsonSerializerSettings: null, enableSsl: enableSsl, host: host, sslCert: sslCert, sslKey: sslKey, useRemoteMockService);
         }
 
         public IMockProviderService MockService(
@@ -76,7 +81,8 @@ namespace PactNet
             bool enableSsl = false, 
             IPAddress host = IPAddress.Loopback, 
             string sslCert = null, 
-            string sslKey = null)
+            string sslKey = null,
+            bool useRemoteMockService = false)
         {
             if (string.IsNullOrEmpty(ConsumerName))
             {
@@ -90,13 +96,15 @@ namespace PactNet
                     "ProviderName has not been set, please supply a provider name using the HasPactWith method.");
             }
 
-            if (_mockProviderService != null)
+            if (_mockProviderService != null && useRemoteMockService == false )
             {
                 _mockProviderService.Stop();
             }
 
             _mockProviderService = _mockProviderServiceFactory(port, enableSsl, ConsumerName, ProviderName, host,
                 jsonSerializerSettings, sslCert, sslKey);
+
+            _mockProviderService.UseRemoteMockService = useRemoteMockService;
 
             _mockProviderService.Start();
 
@@ -108,7 +116,7 @@ namespace PactNet
             if (_mockProviderService == null)
             {
                 throw new InvalidOperationException(
-                    "The Pact file could not be saved because the mock provider service is not initialised. Please initialise by calling the MockService() method.");
+                    "The Pact file could not be saved because the mock provider service is not initialized. Please initialise by calling the MockService() method.");
             }
 
             PersistPactFile();
@@ -117,7 +125,14 @@ namespace PactNet
 
         private void PersistPactFile()
         {
-            _mockProviderService.SendAdminHttpRequest(HttpVerb.Post, Constants.PactPath);
+            var fileNameAndPathToSavePactTo = new Dictionary<string, string>();
+
+            if (_mockProviderService.UseRemoteMockService)
+            {
+                fileNameAndPathToSavePactTo.Add("fileNameAndPath", $"{_pactDir}\\{ConsumerName.ToLower()}{ProviderName.ToLower()}.json");
+            }
+
+            _mockProviderService.SendAdminHttpRequest(HttpVerb.Post, Constants.PactPath, fileNameAndPathToSavePactTo);
         }
     }
 }

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -132,7 +132,7 @@ namespace PactNet
                 fileNameAndPathToSavePactTo.Add("fileNameAndPath", $"{_pactDir}\\{ConsumerName.ToLower()}{ProviderName.ToLower()}.json");
             }
 
-            _mockProviderService.SendAdminHttpRequest(HttpVerb.Post, Constants.PactPath, fileNameAndPathToSavePactTo);
+            _mockProviderService.SendAdminHttpRequest(HttpVerb.Post, Constants.PactPath, fileNameAndPathToSavePactTo.Count == 0? null : fileNameAndPathToSavePactTo);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -415,6 +415,39 @@ var sslKey = @"{PathTo}\localhost.key";
 MockProviderService = PactBuilder.MockService(MockServerPort, true, IPAddress.Any, sslCrt, sslKey);
 ```
 
+### Using a Remote Mock Server Service to execute Consumer tests
+
+It is possible to execute your consumer test against any remote Mock Server (including a docker container). 
+
+In that case you don't need any other package than PactNet. (Ruby packages are not required i.e.: PactNet.Windows/PactNet.OSX, PactNet.Linux.*)
+
+This also fix the building issues of path too long in windows with ruby packages.
+
+To run your consumer tests against a remote server, in PactBuilder class, set the "useRemoteMockService" parameter to true:
+
+```c#
+ PactBuilder.MockService(MockServerPort, useRemoteMockService = true);
+```
+
+Then simply use the remote host url and port to send the call to your remote server.
+
+The pacts file generated this way will be saved to the path that you define in the PactDir property of PactConfig object.
+
+You can run a remote mock server service with the [pact-cli docker container](https://hub.docker.com/r/pactfoundation/pact-cli) as follow:
+
+```
+docker run -dit \
+  --rm \
+  --name pact-mock-service \
+  -p 1234:1234 \
+  -v ${HOST_PACT_DIRECTORY}:/tmp/pacts \
+  pactfoundation/pact-cli:latest \
+  mock-service \
+  -p 1234 \
+  --host 0.0.0.0 \
+  --pact-dir /tmp/pacts
+```
+
 ### Publishing Pacts to a Broker
 The Pact broker is a useful tool that can be used to share pacts between the consumer and provider. In order to make this easy, below are a couple of options for publishing your Pacts to a Pact Broker.
 


### PR DESCRIPTION

Add the possibility to use a remote mock server service for the consumer tests. 

For instance a remote mock server could be call to a pact-cli docker container.

To run your consumer tests against a remote server, in PactBuilder class, set the "useRemoteMockService" parameter to true. 

See [readme.md](https://github.com/pact-foundation/pact-net/commit/bec336dbf35c12ef7d889f528c45ee6d2897c8af) for more details 

Fix the following issues:

- Remote Mock Server [Issue #245](https://github.com/pact-foundation/pact-net/issues/245)
- Build failing for PactNet.Windows Ruby file Path being too long. [Issue #163](https://github.com/pact-foundation/pact-net/issues/163)

