### PR TITLE
fix: pact verifier config and added new tests

### DIFF
--- a/PactNet.Tests/Core/PactVerifierHostConfigTests.cs
+++ b/PactNet.Tests/Core/PactVerifierHostConfigTests.cs
@@ -249,6 +249,7 @@ namespace PactNet.Tests.Core
         }
 
         [Fact]
+        [Obsolete]
         public void Ctor_WhenCalledWithCustomHeader_SetsTheCorrectArgs()
         {
             var config = GetSubject(baseUri: new Uri("http://127.0.0.1"), 

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -12,8 +12,8 @@ namespace PactNet.Tests
 
         [Theory]
         [InlineData( "bad:name", UsernameContainsColunMessage  ) ] // RFC 2617 compliance
-        [InlineData( ""        , UsernameIsEmptyOrNullMessage  ) ] 
-        [InlineData( null      , UsernameIsEmptyOrNullMessage  ) ]
+        [InlineData( "", UsernameIsEmptyOrNullMessage  ) ] 
+        [InlineData( null, UsernameIsEmptyOrNullMessage  ) ]
         public void Ctor_WhenUserNameIsNotAccpetable(string username, string expectedMessage)
         {
             Exception e = Assert.Throws <ArgumentException> (() => new PactUriOptions(username, "dummyval"));
@@ -22,7 +22,7 @@ namespace PactNet.Tests
 
         [Theory]
         [InlineData( null, PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
-        [InlineData( ""  , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
+        [InlineData( "", PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
         public void Ctor_WhenPasswordIsNotAccpetable(string password, string expectedMessage)
         {
             Exception e = Assert.Throws <ArgumentException> (() => new PactUriOptions("dummyval", password));
@@ -30,9 +30,9 @@ namespace PactNet.Tests
         }
 
         [Theory]
-        [InlineData("some@user","password")] // RFC 2716
-        [InlineData("someuser" ,"password")]
-        [InlineData("someuser" ,"pass word")] // RFC 2716
+        [InlineData("some@user", "password")] // RFC 2716
+        [InlineData("someuser" , "password")]
+        [InlineData("someuser" , "pass word")] // RFC 2716
         public void Ctor_AllowUserNamesAndPasswords(string username, string password )
         {
             var options = new PactUriOptions(username, password);

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -6,7 +6,8 @@ namespace PactNet.Tests
     public class PactUriOptionsTests
     {
 
-        // This is an experimental test set. Use of Data Driving improves readabilit and 
+        // This is an experimental test set.
+        // Use of Data Driving improves readability and 
         // shows all the permutations run by one test
         [Theory]
         [InlineData( ""        , ""         ) ] 

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -15,6 +15,83 @@ namespace PactNet.Tests
         }
 
         [Fact]
+        public void Ctor_With_ValidUserNamePassword()
+        {
+            const string username = "Aladdin";
+            const string password = "open sesame";
+            const string expectedAuthScheme = "Basic";
+            const string expectedAuthValue = "QWxhZGRpbjpvcGVuIHNlc2FtZQ==";
+
+            var options = new PactUriOptions(username, password);
+
+            Assert.Equal(expectedAuthScheme, options.AuthorizationScheme);
+            Assert.Equal(expectedAuthValue, options.AuthorizationValue);
+
+        }
+
+        [Fact]
+        public void Ctor_SetUserNameWhenTokenIsSet_ThrowsInvalidOperationException()
+        {
+            const string username = "Aladdin";
+            const string password = "open sesame";
+            const string token = "sometokenvalue";
+
+            var options = new PactUriOptions(token);
+
+            Assert.Throws<InvalidOperationException>( () => options.SetBasicAuthentication(username, password) );
+
+        }
+
+        [Fact]
+        public void Ctor_SetBearerTokenWhenUserNamePasswordEmptyAreSet_ThrowsArgumentException()
+        {
+            const string username = "Aladdin";
+            const string password = "";
+
+            Assert.Throws< ArgumentException>( () => new PactUriOptions(username, password) );
+        }
+
+        [Fact]
+        public void Ctor_SetBearerTokenWhenUserNamePasswordNullAreSet_ThrowsArgumentException()
+        {
+            const string username = "Aladdin";
+            const string password = null;
+
+            Assert.Throws<ArgumentException>( () => new PactUriOptions(username, password));
+        }
+
+        [Fact]
+        public void Ctor_SetBearerTokenWhenUserNameEmptyPasswordAreSet_ThrowsArgumentException()
+        {
+            const string username = "";
+            const string password = "password";
+
+            Assert.Throws<ArgumentException>( () => new PactUriOptions(username, password));
+        }
+
+        [Fact]
+        public void Ctor_SetBearerTokenWhenUserNameNullPasswordAreSet_ThrowsArgumentException()
+        {
+            const string username = null;
+            const string password = "password";
+
+            Assert.Throws<ArgumentException>(() => new PactUriOptions(username, password));
+        }
+
+
+        [Fact]
+        public void Ctor_SetBearerTokenWhenUserNamePasswordAreSet_ThrowsInvalidOperationException()
+        {
+            const string username = "Aladdin";
+            const string password = "open sesame";
+            const string token = "sometokenvalue";
+
+            var options = new PactUriOptions(username, password);
+
+            Assert.Throws<InvalidOperationException>(() => options.SetBearerAuthentication(token));
+        }
+
+        [Fact]
         public void Ctor_WithInvalidUsername_ThrowsArgumentException()
         {
             const string username = "some:user";
@@ -30,6 +107,28 @@ namespace PactNet.Tests
             const string password = "";
 
             Assert.Throws<ArgumentException>(() => new PactUriOptions().SetBasicAuthentication(username, password));
+        }
+
+        [Fact]
+        public void Ctor_UserNameWithAtSymbol()
+        {
+            const string username = "some@user";
+            const string password = "password";
+
+            var options = new PactUriOptions(username, password);
+
+            Assert.Equal(options.Username, username);
+        }
+
+        [Fact]
+        public void Ctor_PasswordWithAtSymbol()
+        {
+            const string username = "someuser";
+            const string password = "pass@word";
+
+            var options = new PactUriOptions(username, password);
+
+            Assert.Equal(options.Password, password);
         }
 
         [Fact]
@@ -87,6 +186,54 @@ namespace PactNet.Tests
             var options = new PactUriOptions().SetBearerAuthentication(token);
 
             Assert.Equal(token, options.Token);
+        }
+
+        [Fact]
+        public void Ctor_SetSslCaPathEmpty_ThrowsArgumentException()
+        {
+            const string sslpath = "";
+
+            Assert.Throws<ArgumentException>(() => new PactUriOptions().SetSslCaFilePath(sslpath));
+        }
+
+        [Fact]
+        public void Ctor_SetSslCaPathNull_ThrowsArgumentException()
+        {
+            const string sslpath = null;
+
+            Assert.Throws<ArgumentException>(() => new PactUriOptions().SetSslCaFilePath(sslpath));
+        }
+
+        [Fact]
+        public void CTor_SetHttpProxyEmpty_ThrowsArgumentException()
+        {
+            const string proxy = "";
+            Assert.Throws<ArgumentException>(() => new PactUriOptions().SetHttpProxy(proxy));
+        }
+
+        [Fact]
+        public void CTor_SetHttpProxyNull_ThrowsArgumentException()
+        {
+            const string proxy = null;
+            Assert.Throws<ArgumentException>(() => new PactUriOptions().SetHttpProxy(proxy));
+        }
+
+
+
+        [Fact]
+        public void CTor_SetHttpsProxiesEmpty_ThrowsArgumentException()
+        {
+            const string httpProxy = "somevalue";
+            const string httpsProxy = "";
+            Assert.Throws<ArgumentException>( () => new PactUriOptions().SetHttpProxy( httpProxy, httpsProxy ) );
+        }
+
+        [Fact]
+        public void CTor_SetHttpsProxiesNull_ThrowsArgumentException()
+        {
+            const string httpProxy = "somevalue";
+            const string httpsProxy = null;
+            Assert.Throws<ArgumentException>(() => new PactUriOptions().SetHttpProxy( httpProxy, httpsProxy ) );
         }
     }
 }

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -5,6 +5,23 @@ namespace PactNet.Tests
 {
     public class PactUriOptionsTests
     {
+
+        // This is an experimental test set. Use of Data Driving improves readabilit and 
+        // shows all the permutations run by one test
+        [Theory]
+        [InlineData( ""        , ""         ) ] 
+        [InlineData( null      , ""         ) ]
+        [InlineData( ""        , null       ) ]
+        [InlineData( null      , null       ) ]
+        [InlineData( "bad:name", ""         ) ] // RFC 2617 compliance
+        [InlineData( "bad:name", null       ) ] // RFC 2617 compliance
+        [InlineData( "goodname", null       ) ] // RFC 2617 compliance
+        [InlineData( "goodname", ""         ) ] // RFC 2617 compliance
+        public void Ctor_takesUserNameandPasswordParamsThatThrowArgException(string username, string password)
+        {
+            Assert.Throws <ArgumentException> (() => new PactUriOptions(username, password));
+        }
+
         [Fact]
         public void Ctor_WithEmptyUsername_ThrowsArgumentException()
         {

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -21,8 +21,8 @@ namespace PactNet.Tests
         }
 
         [Theory]
-        [InlineData( null          , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
-        [InlineData( ""            , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
+        [InlineData( null, PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
+        [InlineData( ""  , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
         public void Ctor_WhenPasswordIsNotAccpetable(string password, string expectedMessage)
         {
             Exception e = Assert.Throws <ArgumentException> (() => new PactUriOptions("dummyval", password));

--- a/PactNet.Tests/PactUriOptionsTests.cs
+++ b/PactNet.Tests/PactUriOptionsTests.cs
@@ -11,7 +11,7 @@ namespace PactNet.Tests
         const string UsernameContainsColunMessage = "username contains a ':' character, which is not allowed.";
 
         [Theory]
-        [InlineData( "bad:name", UsernameContainsColunMessage  ) ] 
+        [InlineData( "bad:name", UsernameContainsColunMessage  ) ] // RFC 2617 compliance
         [InlineData( ""        , UsernameIsEmptyOrNullMessage  ) ] 
         [InlineData( null      , UsernameIsEmptyOrNullMessage  ) ]
         public void Ctor_WhenUserNameIsNotAccpetable(string username, string expectedMessage)
@@ -23,9 +23,9 @@ namespace PactNet.Tests
         [Theory]
         [InlineData( null          , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
         [InlineData( ""            , PasswordIsNullOrEmptyMessage ) ] // RFC 2617 compliance
-        public void Ctor_WhenPasswordIsNotAccpetable(string username, string expectedMessage)
+        public void Ctor_WhenPasswordIsNotAccpetable(string password, string expectedMessage)
         {
-            Exception e = Assert.Throws <ArgumentException> (() => new PactUriOptions(username, "dummyval"));
+            Exception e = Assert.Throws <ArgumentException> (() => new PactUriOptions("dummyval", password));
             Assert.Equal(expectedMessage , e.Message);
         }
 

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -5,103 +5,86 @@ namespace PactNet.Tests
 {
     public class PactVerifierConfigTests
     {
+        readonly PactVerifierConfig _verifierConfig = null;
+        public PactVerifierConfigTests()
+        {
+             _verifierConfig = new PactVerifierConfig();
+        }
+
         [Fact]
+        [System.Obsolete]
         public void PactVertifier_Init_State_CustomHeaderIsNull()
         {
-            var config = new PactVerifierConfig();
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Null(config.CustomHeader);
-#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.Null(_verifierConfig.CustomHeader);
 
         }
 
         [Fact]
         public void PactVertifier_Init_State_OutputersIsNotNull()
         {
-            var config = new PactVerifierConfig();
-
-            Assert.NotNull( config.Outputters );
-
+            Assert.NotNull( _verifierConfig.Outputters );
         }
 
         [Fact]
         public void PactVertifier_Init_State_CustomHeadersCountIsZero()
         {
-            var config = new PactVerifierConfig();
-
-            Assert.Equal(0, config.CustomHeaders.Count);
-
+            Assert.Equal(0, _verifierConfig.CustomHeaders.Count);
         }
 
         [Fact]
+        [System.Obsolete]
         public void CustomHeader_backwardCompatibility_ConfirmKeyPairinCustomHeaders()
         {
-            var config = new PactVerifierConfig();
-
             string dummy_key = "dummyKey";
             string dummy_value = "dummyValue";
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            // set the CustomHeader value
-            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
 
-            // Confirm CustomHeaders contains the supplied Key
-            Assert.True(config.CustomHeaders.ContainsKey(config.CustomHeader.Value.Key));
-#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.True(_verifierConfig.CustomHeaders.ContainsKey(_verifierConfig.CustomHeader.Value.Key));
 
         }
 
         [Fact]
+        [System.Obsolete]
         public void CustomHeader_backwardCompatibility_SetCustomHeaderToNull_ConfirmCustomHeadersCountIsZero()
         {
-
-            var config = new PactVerifierConfig();
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            // set the CustomHeader value
-            config.CustomHeader = null;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            // Confirm CustomHeaders contains the supplied Key
-            Assert.Equal(0 ,config.CustomHeaders.Count);
-        }
-
-        [Fact]
-        public void CustomHeader_backwardCompatibility_AddCustomHeaderAndConfirmCustomHeadersSizeIsOne()
-        {
-            var config = new PactVerifierConfig();
-
             string dummy_key = "dummyKey";
             string dummy_value = "dummyValue";
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            // set the CustomHeader value
-            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
-#pragma warning restore CS0618 // Type or member is obsolete
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
 
-            // check the action has added one CustomHeader
-            Assert.Equal(1, config.CustomHeaders.Count);
+            _verifierConfig.CustomHeader = null;
+
+            Assert.Equal(0 , _verifierConfig.CustomHeaders.Count);
+        }
+
+        [Fact]
+        [System.Obsolete]
+        public void CustomHeader_backwardCompatibility_AddCustomHeaderAndConfirmCustomHeadersSizeIsOne()
+        {
+            string dummy_key = "dummyKey";
+            string dummy_value = "dummyValue";
+
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+
+            Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
 
         }
 
         [Fact]
+        [System.Obsolete]
         public void CustomHeader_backwardCompatibility_ChangeCustomHeader_ConfirmCustomHeadersSizeIsOne()
         {
-            var config = new PactVerifierConfig();
-
             string dummy_key = "dummyKey";
             string dummy_value = "dummyValue";
             string prefix = "new";
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            // set the CustomHeader value
-            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
-            config.CustomHeader = new KeyValuePair<string, string>(prefix + dummy_key, prefix + dummy_value);
-#pragma warning restore CS0618 // Type or member is obsolete
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(prefix + dummy_key, prefix + dummy_value);
 
             // check the action has added one CustomHeader
-            Assert.Equal(1, config.CustomHeaders.Count);
+            Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
 
         }
     }

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -1,6 +1,4 @@
-﻿using PactNet.Infrastructure.Outputters;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Xunit;
 
 namespace PactNet.Tests

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -63,7 +63,7 @@ namespace PactNet.Tests
         {
             _verifierConfig.CustomHeader = GetDummyHeader();
 
-            Assert.False(_verifierConfig.CustomHeaders.ContainsKey(GetDummyHeader().Key));
+            Assert.True(_verifierConfig.CustomHeaders.ContainsKey(GetDummyHeader().Key));
         }
 
         [Fact]

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -15,9 +15,7 @@ namespace PactNet.Tests
         [System.Obsolete]
         public void PactVertifier_Init_State_CustomHeaderIsNull()
         {
-
             Assert.Null(_verifierConfig.CustomHeader);
-
         }
 
         [Fact]
@@ -42,7 +40,6 @@ namespace PactNet.Tests
             _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
 
             Assert.True(_verifierConfig.CustomHeaders.ContainsKey(_verifierConfig.CustomHeader.Value.Key));
-
         }
 
         [Fact]
@@ -69,7 +66,6 @@ namespace PactNet.Tests
             _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
 
             Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
-
         }
 
         [Fact]
@@ -85,7 +81,6 @@ namespace PactNet.Tests
 
             // check the action has added one CustomHeader
             Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
-
         }
     }
 }

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -59,15 +59,6 @@ namespace PactNet.Tests
 
         [Fact]
         [Obsolete]
-        public void WhenCustomHeaderIsNotNull_CustomHeadersShouldContainKey()
-        {
-            _verifierConfig.CustomHeader = GetDummyHeader();
-
-            Assert.True(_verifierConfig.CustomHeaders.ContainsKey(GetDummyHeader().Key));
-        }
-
-        [Fact]
-        [Obsolete]
         public void WhenCustomHeaderHasPreviousValue_AndChangingCustomHeader_ShouldPreviousValueNotBeAvailableThroughCustomHeadersCollectionAnymore()
         {
             _verifierConfig.CustomHeader = GetDummyHeader();

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -1,21 +1,28 @@
 ﻿using System.Collections.Generic;
+using System;
 using Xunit;
 
 namespace PactNet.Tests
 {
     public class PactVerifierConfigTests
     {
-        readonly PactVerifierConfig _verifierConfig = null;
+        private readonly PactVerifierConfig _verifierConfig;
+
         public PactVerifierConfigTests()
         {
              _verifierConfig = new PactVerifierConfig();
         }
 
+        private KeyValuePair<string,string> GetDummyHeader()
+        {
+            return new KeyValuePair<string, string>("dummy_key", "dummy_value");
+        }
+
         [Fact]
-        [System.Obsolete]
+        [Obsolete]
         public void PactVertifier_Init_State_CustomHeaderIsNull()
         {
-            Assert.Null(_verifierConfig.CustomHeader);
+            Assert.Null( _verifierConfig.CustomHeader );
         }
 
         [Fact]
@@ -31,56 +38,43 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        [System.Obsolete]
-        public void CustomHeader_backwardCompatibility_ConfirmKeyPairinCustomHeaders()
+        [Obsolete]
+        public void WhenCustomHeaderIsNotNull_ShouldBeAvailableThroughCustomHeadersCollection()
         {
-            string dummy_key = "dummyKey";
-            string dummy_value = "dummyValue";
-
-            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+            _verifierConfig.CustomHeader = GetDummyHeader();
 
             Assert.True(_verifierConfig.CustomHeaders.ContainsKey(_verifierConfig.CustomHeader.Value.Key));
         }
 
         [Fact]
-        [System.Obsolete]
-        public void CustomHeader_backwardCompatibility_SetCustomHeaderToNull_ConfirmCustomHeadersCountIsZero()
+        [Obsolete]
+        public void WhenCustomHeaderHasPreviousValue_AndCustomHeaderChangedToNull_ShouldPreviousValueIsNotAvailableInCustomHeaders()
         {
-            string dummy_key = "dummyKey";
-            string dummy_value = "dummyValue";
-
-            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+            _verifierConfig.CustomHeader = GetDummyHeader();
 
             _verifierConfig.CustomHeader = null;
 
-            Assert.Equal(0 , _verifierConfig.CustomHeaders.Count);
+            Assert.False( _verifierConfig.CustomHeaders.ContainsKey( GetDummyHeader().Key) );
         }
 
         [Fact]
-        [System.Obsolete]
-        public void CustomHeader_backwardCompatibility_AddCustomHeaderAndConfirmCustomHeadersSizeIsOne()
+        [Obsolete]
+        public void WhenCustomHeaderIsNotNull_CustomHeadersShouldContainKey()
         {
-            string dummy_key = "dummyKey";
-            string dummy_value = "dummyValue";
+            _verifierConfig.CustomHeader = GetDummyHeader();
 
-            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
-
-            Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
+            Assert.False(_verifierConfig.CustomHeaders.ContainsKey(GetDummyHeader().Key));
         }
 
         [Fact]
-        [System.Obsolete]
-        public void CustomHeader_backwardCompatibility_ChangeCustomHeader_ConfirmCustomHeadersSizeIsOne()
+        [Obsolete]
+        public void WhenCustomHeaderHasPreviousValue_AndChangingCustomHeader_ShouldPreviousValueNotBeAvailableThroughCustomHeadersCollectionAnymore()
         {
-            string dummy_key = "dummyKey";
-            string dummy_value = "dummyValue";
-            string prefix = "new";
+            _verifierConfig.CustomHeader = GetDummyHeader();
 
-            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
-            _verifierConfig.CustomHeader = new KeyValuePair<string, string>(prefix + dummy_key, prefix + dummy_value);
+            _verifierConfig.CustomHeader = new KeyValuePair<string, string>("new_dummy_key", "new_dummy_value");
 
-            // check the action has added one CustomHeader
-            Assert.Equal(1, _verifierConfig.CustomHeaders.Count);
+            Assert.False( _verifierConfig.CustomHeaders.ContainsKey(GetDummyHeader().Key) );
         }
     }
 }

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using PactNet.Infrastructure.Outputters;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -7,44 +8,102 @@ namespace PactNet.Tests
     public class PactVerifierConfigTests
     {
         [Fact]
-        public void CustomHeader_backwardCompatibility_getValue()
+        public void PactVertifier_Init_State_CustomHeaderIsNull()
         {
             var config = new PactVerifierConfig();
 
-            KeyValuePair<string, string> keyValuePair = new KeyValuePair<string, string> ( "key name", "value");
-
 #pragma warning disable CS0618 // Type or member is obsolete
-            config.CustomHeader = keyValuePair;
-
-            Assert.Equal(config.CustomHeader, keyValuePair);
+            Assert.Null(config.CustomHeader);
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.True(config.CustomHeaders.Contains(keyValuePair));
-            Assert.Equal(config.CustomHeaders.Count, 1);
 
         }
 
         [Fact]
-        public void CustomHeader_backwardCompatibility()
+        public void PactVertifier_Init_State_OutputersIsNotNull()
         {
             var config = new PactVerifierConfig();
 
-            KeyValuePair<string, string> oldKeyValuePair = new KeyValuePair<string, string>("key name", "value");
+            Assert.NotNull( config.Outputters );
 
-            // Expect an initial length of 0
-            Assert.Equal(config.CustomHeaders.Count, 0);
+        }
+
+        [Fact]
+        public void PactVertifier_Init_State_CustomHeadersCountIsZero()
+        {
+            var config = new PactVerifierConfig();
+
+            Assert.Equal(0, config.CustomHeaders.Count);
+
+        }
+
+        [Fact]
+        public void CustomHeader_backwardCompatibility_ConfirmKeyPairinCustomHeaders()
+        {
+            var config = new PactVerifierConfig();
+
+            string dummy_key = "dummyKey";
+            string dummy_value = "dummyValue";
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            config.CustomHeader = oldKeyValuePair;
-            // confirm the value was added
-            Assert.Equal(config.CustomHeaders.Count, 1);
-            config.CustomHeader = new KeyValuePair<string, string>("new key name", "new value");
+            // set the CustomHeader value
+            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+
+            // Confirm CustomHeaders contains the supplied Key
+            Assert.True(config.CustomHeaders.ContainsKey(config.CustomHeader.Value.Key));
 #pragma warning restore CS0618 // Type or member is obsolete
 
+        }
+
+        [Fact]
+        public void CustomHeader_backwardCompatibility_SetCustomHeaderToNull_ConfirmCustomHeadersCountIsZero()
+        {
+
+            var config = new PactVerifierConfig();
+
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.NotEqual(config.CustomHeader, oldKeyValuePair);
+            // set the CustomHeader value
+            config.CustomHeader = null;
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.False(config.CustomHeaders.Contains(oldKeyValuePair));
-            Assert.Equal(config.CustomHeaders.Count, 1);
+
+            // Confirm CustomHeaders contains the supplied Key
+            Assert.Equal(0 ,config.CustomHeaders.Count);
+        }
+
+        [Fact]
+        public void CustomHeader_backwardCompatibility_AddCustomHeaderAndConfirmCustomHeadersSizeIsOne()
+        {
+            var config = new PactVerifierConfig();
+
+            string dummy_key = "dummyKey";
+            string dummy_value = "dummyValue";
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            // set the CustomHeader value
+            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // check the action has added one CustomHeader
+            Assert.Equal(1, config.CustomHeaders.Count);
+
+        }
+
+        [Fact]
+        public void CustomHeader_backwardCompatibility_ChangeCustomHeader_ConfirmCustomHeadersSizeIsOne()
+        {
+            var config = new PactVerifierConfig();
+
+            string dummy_key = "dummyKey";
+            string dummy_value = "dummyValue";
+            string prefix = "new";
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            // set the CustomHeader value
+            config.CustomHeader = new KeyValuePair<string, string>(dummy_key, dummy_value);
+            config.CustomHeader = new KeyValuePair<string, string>(prefix + dummy_key, prefix + dummy_value);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // check the action has added one CustomHeader
+            Assert.Equal(1, config.CustomHeaders.Count);
 
         }
     }

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace PactNet.Tests

--- a/PactNet.Tests/PactVerifierConfigTests.cs
+++ b/PactNet.Tests/PactVerifierConfigTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PactNet.Tests
+{
+    public class PactVerifierConfigTests
+    {
+        [Fact]
+        public void CustomHeader_backwardCompatibility_getValue()
+        {
+            var config = new PactVerifierConfig();
+
+            KeyValuePair<string, string> keyValuePair = new KeyValuePair<string, string> ( "key name", "value");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            config.CustomHeader = keyValuePair;
+
+            Assert.Equal(config.CustomHeader, keyValuePair);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.True(config.CustomHeaders.Contains(keyValuePair));
+            Assert.Equal(config.CustomHeaders.Count, 1);
+
+        }
+
+        [Fact]
+        public void CustomHeader_backwardCompatibility()
+        {
+            var config = new PactVerifierConfig();
+
+            KeyValuePair<string, string> oldKeyValuePair = new KeyValuePair<string, string>("key name", "value");
+
+            // Expect an initial length of 0
+            Assert.Equal(config.CustomHeaders.Count, 0);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            config.CustomHeader = oldKeyValuePair;
+            // confirm the value was added
+            Assert.Equal(config.CustomHeaders.Count, 1);
+            config.CustomHeader = new KeyValuePair<string, string>("new key name", "new value");
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.NotEqual(config.CustomHeader, oldKeyValuePair);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.False(config.CustomHeaders.Contains(oldKeyValuePair));
+            Assert.Equal(config.CustomHeaders.Count, 1);
+
+        }
+    }
+}

--- a/PactNet/PactVerifierConfig.cs
+++ b/PactNet/PactVerifierConfig.cs
@@ -24,7 +24,7 @@ namespace PactNet
                 }
                 if (_customHeader != null)
                 {
-                    CustomHeaders.Remove(_customHeader.Value.Value);
+                    CustomHeaders.Remove(_customHeader.Value.Key);
                 }
                 _customHeader = value;
             }

--- a/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
+++ b/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
@@ -74,7 +74,7 @@
         "body": {
           "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
           "eventType": "DetailsView",
-          "timestamp": "2021-05-10T06:36:43.5588187Z"
+          "timestamp": "2021-05-11T09:01:07.4125783Z"
         },
         "matchingRules": {
           "$.headers.Server": {

--- a/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
+++ b/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
@@ -74,7 +74,7 @@
         "body": {
           "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
           "eventType": "DetailsView",
-          "timestamp": "2021-05-08T11:30:58.7911912Z"
+          "timestamp": "2021-05-10T06:36:43.5588187Z"
         },
         "matchingRules": {
           "$.headers.Server": {

--- a/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
+++ b/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
@@ -74,7 +74,7 @@
         "body": {
           "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
           "eventType": "DetailsView",
-          "timestamp": "2021-05-03T23:12:59.2284654Z"
+          "timestamp": "2021-05-08T11:30:58.7911912Z"
         },
         "matchingRules": {
           "$.headers.Server": {

--- a/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
+++ b/Samples/EventApi/Consumer.Tests/pacts/event_api_consumer-event_api.json
@@ -74,7 +74,7 @@
         "body": {
           "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
           "eventType": "DetailsView",
-          "timestamp": "2021-05-11T09:01:07.4125783Z"
+          "timestamp": "2021-05-15T08:33:25.1378551Z"
         },
         "matchingRules": {
           "$.headers.Server": {


### PR DESCRIPTION
When replacing the value of CustomHeader, the CustomHeaders dictionary grows instead of removing the previous value