### PR TITLE
feat: add useIpv4LoopbackOnly flag

### DIFF
--- a/PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
@@ -57,18 +57,15 @@ namespace PactNet.Tests.IntegrationTests
                 .WillRespondWith(response);
 
             // Act
-            using (var httpClient = CreateHttpClient())
+            using (var httpContent = new StringContent(@"{""left"":1,""right"":1}", Encoding.UTF8, "application/json"))
             {
-                using (var httpContent = new StringContent(@"{""left"":1,""right"":1}", Encoding.UTF8, "application/json"))
+                using (var httpResponse = await Pact.HttpClient.PostAsync("/calculator/add", httpContent))
                 {
-                    using (var httpResponse = await httpClient.PostAsync("/calculator/add", httpContent))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
 
-                        string json = await httpResponse.Content.ReadAsStringAsync();
+                    string json = await httpResponse.Content.ReadAsStringAsync();
 
-                        Assert.Equal(@"{""result"":2}", json);
-                    }
+                    Assert.Equal(@"{""result"":2}", json);
                 }
             }
 
@@ -115,18 +112,15 @@ namespace PactNet.Tests.IntegrationTests
                 .WillRespondWith(response);
 
             // Act
-            using (var httpClient = CreateHttpClient())
+            using (var httpContent = new StringContent(@"{""left"":2,""right"":3}", Encoding.UTF8, "application/json"))
             {
-                using (var httpContent = new StringContent(@"{""left"":2,""right"":3}", Encoding.UTF8, "application/json"))
+                using (var httpResponse = await Pact.HttpClient.PostAsync("/calculator/subtract", httpContent))
                 {
-                    using (var httpResponse = await httpClient.PostAsync("/calculator/subtract", httpContent))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
 
-                        string json = await httpResponse.Content.ReadAsStringAsync();
+                    string json = await httpResponse.Content.ReadAsStringAsync();
 
-                        Assert.Equal(@"{""result"":-1}", json);
-                    }
+                    Assert.Equal(@"{""result"":-1}", json);
                 }
             }
 
@@ -144,14 +138,6 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         protected T Pact { get; }
-
-        public HttpClient CreateHttpClient()
-        {
-            return new HttpClient()
-            {
-                BaseAddress = Pact.PactBrokerUri,
-            };
-        }
     }
 
     public sealed class CalculatorApiPact : ApiPact
@@ -184,9 +170,14 @@ namespace PactNet.Tests.IntegrationTests
             PactBrokerUri = new UriBuilder()
             {
                 Host = "localhost",
-                Port = 4322,
+                Port = 4323,
                 Scheme = "http",
             }.Uri;
+
+            HttpClient = new HttpClient()
+            {
+                BaseAddress = PactBrokerUri,
+            };
         }
 
         ~ApiPact()
@@ -195,6 +186,7 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         public Uri PactBrokerUri { get; }
+        public HttpClient HttpClient { get; }
 
         public IMockProviderService PactProvider
         {

--- a/PactNet.Tests/PactBuilderUsingFactory2Tests.cs
+++ b/PactNet.Tests/PactBuilderUsingFactory2Tests.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NSubstitute;
+using PactNet.Configuration.Json;
+using PactNet.Mocks.MockHttpService;
+using PactNet.Mocks.MockHttpService.Models;
+using PactNet.Models;
+using Xunit;
+
+namespace PactNet.Tests
+{
+    public class PactBuilderUsingFactory2Tests
+    {
+        private IPactBuilder GetSubject()
+        {
+            PactConfig config = new PactConfig();
+            return new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                new MockProviderService(port, enableSsl, consumerName, providerName, config, host,
+                    jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly));
+        }
+
+        [Fact]
+        public void ServiceConsumer_WithConsumerName_SetsConsumerName()
+        {
+            const string consumerName = "My Service Consumer";
+            var pactBuilder = GetSubject();
+
+            pactBuilder.ServiceConsumer(consumerName);
+
+            Assert.Equal(consumerName, ((PactBuilder)pactBuilder).ConsumerName);
+        }
+
+        [Fact]
+        public void ServiceConsumer_WithNullConsumerName_ThrowsArgumentException()
+        {
+            var pactBuilder = GetSubject();
+
+            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(null));
+        }
+
+        [Fact]
+        public void ServiceConsumer_WithEmptyConsumerName_ThrowsArgumentException()
+        {
+            var pactBuilder = GetSubject();
+
+            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(string.Empty));
+        }
+
+        [Fact]
+        public void HasPactWith_WithProviderName_SetsProviderName()
+        {
+            const string providerName = "My Service Provider";
+            var pact = GetSubject();
+
+            pact.HasPactWith(providerName);
+
+            Assert.Equal(providerName, ((PactBuilder)pact).ProviderName);
+        }
+
+        [Fact]
+        public void HasPactWith_WithNullProviderName_ThrowsArgumentException()
+        {
+            var pactBuilder = GetSubject();
+
+            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(null));
+        }
+
+        [Fact]
+        public void HasPactWith_WithEmptyProviderName_ThrowsArgumentException()
+        {
+            var pactBuilder = GetSubject();
+
+            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(string.Empty));
+        }
+
+        [Fact]
+        public void MockService_WhenCalled_StartIsCalledAndMockProviderServiceIsReturned()
+        {
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder =
+                new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert,
+                    sslKey, useIpv4LoopbackOnly) => mockMockProviderService);
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            var mockProviderService = pactBuilder.MockService(1234);
+
+            mockMockProviderService.Received(1).Start();
+            Assert.Equal(mockMockProviderService, mockProviderService);
+        }
+
+        [Fact]
+        public void MockService_WhenCalledTwice_StopIsCalledTheSecondTime()
+        {
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder =
+                new PactBuilder((port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert,
+                    sslKey, useIpv4LoopbackOnly) => mockMockProviderService);
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234);
+            mockMockProviderService.Received(0).Stop();
+
+            pactBuilder.MockService(1234);
+            mockMockProviderService.Received(1).Stop();
+        }
+
+        [Fact]
+        public void MockService_WhenCalled_MockProviderServiceFactoryIsInvokedWithSslNotEnabled()
+        {
+            var calledWithSslEnabled = false;
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                {
+                    calledWithSslEnabled = enableSsl;
+                    return mockMockProviderService;
+                });
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234);
+
+            Assert.False(calledWithSslEnabled);
+        }
+
+        [Fact]
+        public void MockService_WhenCalledWithEnableSslFalse_MockProviderServiceFactoryIsInvokedWithSslNotEnabled()
+        {
+            var calledWithSslEnabled = false;
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                {
+                    calledWithSslEnabled = enableSsl;
+                    return mockMockProviderService;
+                });
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234, false);
+
+            Assert.False(calledWithSslEnabled);
+        }
+
+        [Fact]
+        public void MockService_WhenCalledWithEnableSslTrue_MockProviderServiceFactoryIsInvokedWithSslEnabled()
+        {
+            var calledWithSslEnabled = false;
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                {
+                    calledWithSslEnabled = enableSsl;
+                    return mockMockProviderService;
+                });
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234, true);
+
+            Assert.True(calledWithSslEnabled);
+        }
+
+        [Fact]
+        public void
+            MockService_WhenCalledWithJsonSerializerSettings_MockProviderServiceFactoryIsInvokedWithJsonSerializerSettings()
+        {
+            JsonSerializerSettings calledWithSerializerSettings = null;
+            var serializerSettings = new JsonSerializerSettings();
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                {
+                    calledWithSerializerSettings = jsonSerializerSettings;
+                    return mockMockProviderService;
+                });
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234, serializerSettings);
+
+            Assert.Equal(serializerSettings, calledWithSerializerSettings);
+        }
+
+        [Fact]
+        public void
+            MockService_WhenCalledWithNoJsonSerializerSettings_MockProviderServiceFactoryIsInvokedWithNullJsonSerializerSettings()
+        {
+            var calledWithSerializerSettings = new JsonSerializerSettings();
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                {
+                    calledWithSerializerSettings = jsonSerializerSettings;
+                    return mockMockProviderService;
+                });
+
+            pactBuilder
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234);
+
+            Assert.Null(calledWithSerializerSettings);
+        }
+
+        [Fact]
+        public void MockService_WhenCalledWithoutConsumerNameSet_ThrowsInvalidOperationException()
+        {
+            IPactBuilder pactBuilder =
+                new PactBuilder(
+                    (port, ssl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                        Substitute.For<IMockProviderService>());
+            pactBuilder
+                .HasPactWith("Event API");
+
+            Assert.Throws<InvalidOperationException>(() => pactBuilder.MockService(1234));
+        }
+
+        [Fact]
+        public void MockService_WhenCalledWithoutProviderNameSet_ThrowsInvalidOperationException()
+        {
+            IPactBuilder pactBuilder =
+                new PactBuilder(
+                    (port, ssl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                        Substitute.For<IMockProviderService>());
+            pactBuilder
+                .ServiceConsumer("Event Client");
+
+            Assert.Throws<InvalidOperationException>(() => pactBuilder.MockService(1234));
+        }
+
+        [Fact]
+        public void Build_WhenCalledBeforeTheMockProviderServiceIsInitialised_ThrowsInvalidOperationException()
+        {
+            IPactBuilder pactBuilder = new PactBuilder(mockProviderServiceFactory2: null);
+
+            Assert.Throws<InvalidOperationException>(() => pactBuilder.Build());
+        }
+
+        [Fact]
+        public void
+            Build_WhenCalledWithTheMockProviderServiceInitialised_CallsSendAdminHttpRequestOnTheMockProviderService()
+        {
+            const string testConsumerName = "Event Client";
+            const string testProviderName = "Event API";
+            var mockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder =
+                new PactBuilder(
+                    (port, ssl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly) =>
+                        mockProviderService);
+            pactBuilder
+                .ServiceConsumer(testConsumerName)
+                .HasPactWith(testProviderName);
+
+            pactBuilder.MockService(1234);
+
+            pactBuilder.Build();
+
+            mockProviderService.Received(1).SendAdminHttpRequest(HttpVerb.Post, Constants.PactPath);
+        }
+
+        [Fact]
+        public void Build_WhenCalledWithAnInitialisedMockProviderService_StopIsCalledOnTheMockServiceProvider()
+        {
+            var mockMockProviderService = Substitute.For<IMockProviderService>();
+
+            IPactBuilder pactBuilder = new PactBuilder(
+                    (port, enableSsl, consumerName, providerName, host, jsonSerializerSettings, sslCert, sslKey, useIpv4LoopbackOnly)
+                        => mockMockProviderService)
+                .ServiceConsumer("Event Client")
+                .HasPactWith("Event API");
+
+            pactBuilder.MockService(1234);
+
+            pactBuilder.Build();
+
+            mockMockProviderService.Received(1).Stop();
+        }
+    }
+}

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -27,10 +27,11 @@ namespace PactNet.Mocks.MockHttpService
             Func<Uri, IHttpHost> hostFactory,
             int port,
             bool enableSsl,
-            Func<Uri, AdminHttpClient> adminHttpClientFactory)
+            Func<Uri, AdminHttpClient> adminHttpClientFactory,
+            bool useIpv4LoopbackOnly = false)
         {
             _hostFactory = hostFactory;
-            BaseUri = new Uri($"{(enableSsl ? "https" : "http")}://localhost:{port}");
+            BaseUri = new Uri($"{(enableSsl ? "https" : "http")}://{(useIpv4LoopbackOnly ? "127.0.0.1" : "localhost")}:{port}");
             _adminHttpClient = adminHttpClientFactory(BaseUri);
         }
 
@@ -44,12 +45,13 @@ namespace PactNet.Mocks.MockHttpService
         {
         }
 
-        public MockProviderService(int port, bool enableSsl, string consumerName, string providerName, PactConfig config, IPAddress ipAddress, Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings, string sslCert, string sslKey)
+        public MockProviderService(int port, bool enableSsl, string consumerName, string providerName, PactConfig config, IPAddress ipAddress, Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings, string sslCert, string sslKey, bool useIpv4LoopbackOnly = false)
             : this(
                 baseUri => new RubyHttpHost(baseUri, consumerName, providerName, config, ipAddress, sslCert, sslKey),
                 port,
                 enableSsl,
-                baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings))
+                baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings),
+                useIpv4LoopbackOnly: useIpv4LoopbackOnly)
         {
         }
 


### PR DESCRIPTION
Goal: Resolution to https://github.com/pact-foundation/pact-net/issues/303
Issue Description: localhost hostname often binds to ipv4 and ipv6 loopback, which can cause bind issues when running mocks in docker containers that don't allowing binding to ipv6 as standard.
Solution Description:
- Update PactNet/Mocks/MockHttpService/MockProviderService.cs
--- edit internal and public constructor with boolean flag that determine BaseUri to use ipv4 loopback or not
- Update PactNet/PactBuilder.cs
--- add a mockProviderServiceFactory2 that accepts an extra boolean
- Create PactNet.Tests/PactBuilderUsingFactory2Tests.cs
--- this is a copy of tests in PactNet.Tests/PactBuilderTests.cs but using mockProviderServiceFactory2
- Update PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
--- share HttpClient using IClassFixture. see this article on benefits of creating fewer instances of HttpClient https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
--- use port 4323 instead of 4322 since 4322 is used in IntegrationTestsMyApiPact.cs as well. to prevent possible bind conflict.