### PR TITLE
feat: add IPAddress.LoopbackIPv4Only...

### DIFF
--- a/PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
@@ -57,18 +57,15 @@ namespace PactNet.Tests.IntegrationTests
                 .WillRespondWith(response);
 
             // Act
-            using (var httpClient = CreateHttpClient())
+            using (var httpContent = new StringContent(@"{""left"":1,""right"":1}", Encoding.UTF8, "application/json"))
             {
-                using (var httpContent = new StringContent(@"{""left"":1,""right"":1}", Encoding.UTF8, "application/json"))
+                using (var httpResponse = await Pact.HttpClient.PostAsync("/calculator/add", httpContent))
                 {
-                    using (var httpResponse = await httpClient.PostAsync("/calculator/add", httpContent))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
 
-                        string json = await httpResponse.Content.ReadAsStringAsync();
+                    string json = await httpResponse.Content.ReadAsStringAsync();
 
-                        Assert.Equal(@"{""result"":2}", json);
-                    }
+                    Assert.Equal(@"{""result"":2}", json);
                 }
             }
 
@@ -115,18 +112,15 @@ namespace PactNet.Tests.IntegrationTests
                 .WillRespondWith(response);
 
             // Act
-            using (var httpClient = CreateHttpClient())
+            using (var httpContent = new StringContent(@"{""left"":2,""right"":3}", Encoding.UTF8, "application/json"))
             {
-                using (var httpContent = new StringContent(@"{""left"":2,""right"":3}", Encoding.UTF8, "application/json"))
+                using (var httpResponse = await Pact.HttpClient.PostAsync("/calculator/subtract", httpContent))
                 {
-                    using (var httpResponse = await httpClient.PostAsync("/calculator/subtract", httpContent))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
 
-                        string json = await httpResponse.Content.ReadAsStringAsync();
+                    string json = await httpResponse.Content.ReadAsStringAsync();
 
-                        Assert.Equal(@"{""result"":-1}", json);
-                    }
+                    Assert.Equal(@"{""result"":-1}", json);
                 }
             }
 
@@ -144,14 +138,6 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         protected T Pact { get; }
-
-        public HttpClient CreateHttpClient()
-        {
-            return new HttpClient()
-            {
-                BaseAddress = Pact.PactBrokerUri,
-            };
-        }
     }
 
     public sealed class CalculatorApiPact : ApiPact
@@ -184,9 +170,14 @@ namespace PactNet.Tests.IntegrationTests
             PactBrokerUri = new UriBuilder()
             {
                 Host = "localhost",
-                Port = 4322,
+                Port = 4323,
                 Scheme = "http",
             }.Uri;
+
+            HttpClient = new HttpClient()
+            {
+                BaseAddress = PactBrokerUri,
+            };
         }
 
         ~ApiPact()
@@ -195,6 +186,7 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         public Uri PactBrokerUri { get; }
+        public HttpClient HttpClient { get; }
 
         public IMockProviderService PactProvider
         {

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -27,10 +27,11 @@ namespace PactNet.Mocks.MockHttpService
             Func<Uri, IHttpHost> hostFactory,
             int port,
             bool enableSsl,
-            Func<Uri, AdminHttpClient> adminHttpClientFactory)
+            Func<Uri, AdminHttpClient> adminHttpClientFactory,
+            IPAddress ipAddress = IPAddress.Loopback)
         {
             _hostFactory = hostFactory;
-            BaseUri = new Uri($"{(enableSsl ? "https" : "http")}://localhost:{port}");
+            BaseUri = new Uri($"{(enableSsl ? "https" : "http")}://{(ipAddress == IPAddress.LoopbackIpv4Only ? "127.0.0.1" : "localhost")}:{port}");
             _adminHttpClient = adminHttpClientFactory(BaseUri);
         }
 
@@ -49,7 +50,8 @@ namespace PactNet.Mocks.MockHttpService
                 baseUri => new RubyHttpHost(baseUri, consumerName, providerName, config, ipAddress, sslCert, sslKey),
                 port,
                 enableSsl,
-                baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings))
+                baseUri => new AdminHttpClient(baseUri, jsonSerializerSettings),
+                ipAddress)
         {
         }
 

--- a/PactNet/Models/IPAddress.cs
+++ b/PactNet/Models/IPAddress.cs
@@ -3,6 +3,7 @@
     public enum IPAddress
     {
         Any,
-        Loopback
+        Loopback,
+        LoopbackIpv4Only
     }
 }


### PR DESCRIPTION
... and use it to set BaseUri of MockProviderService.

Goal: resolution to https://github.com/pact-foundation/pact-net/issues/307
Issue Description: If /etc/hosts is configured to map DNS(localhost) to IP(127.0.0.1) and IP(::1), then the client for pact-mock-service using DNS(localhost) fails to bind to IP(::1), since it listens only on IP(127.0.0.1).

Solution Description:
- Update PactNet/Models/IPAddress.cs
--- add LoopbackIpv4Only to enum IPAddress
- Update PactNet/Mocks/MockHttpService/MockProviderService.cs
--- add IPAddress argument to internal constructor and use it to set BaseUri with host as IP(127.0.0.1) when IPAddress is LoopbackIpv4Only
- Update PactNet.Tests/IntegrationTests/XunitIntegrationTests.cs
--- share HttpClient using IClassFixture. see this article on benefits of creating fewer instances of HttpClient https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
--- use port 4323 instead of 4322 since 4322 is used in IntegrationTestsMyApiPact.cs as well. to prevent possible bind conflict.

Previous Iterations of pull request with relevant comments:
- https://github.com/pact-foundation/pact-net/pull/304
- https://github.com/pact-foundation/pact-net/pull/306