### PR TITLE
feat!: Replace separate FFI libs with new combined FFI lib

### DIFF
--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -1,61 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MOCK_SERVER_VERSION="0.0.17"
-MOCK_SERVER_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v$MOCK_SERVER_VERSION"
-
-VERIFIER_VERSION="0.0.4"
-VERIFIER_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_ffi-v$VERIFIER_VERSION"
+FFI_VERSION="0.0.0"
+FFI_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$FFI_VERSION"
 
 base_path=$(dirname "$0")
 
 download_native() {
-    base_url="$1"
-    component="$2"
-    file="$3"
-    os="$4"
-    platform="$5"
-    extension="$6"
+    file="$1"
+    os="$2"
+    platform="$3"
+    extension="$4"
 
-    url="$base_url/lib$component-$os-$platform.$extension.gz"
+    # e.g.
+    #   pact_ffi-windows-x86_64.dll.gz
+    #   libpact_ffi-linux-x86_64.so.gz
+    #   libpact_ffi-osx-x86_64.dylib.gz
+    src_file="$file-$os-$platform.$extension.gz"
+    url="$FFI_BASE_URL/$src_file"
     sha="$url.sha256"
 
     path="$base_path/$os/$platform"
+    dest_file="$file.$extension.gz"
     mkdir -p "$path"
 
-    echo "Downloading $component"
-    echo "    Platform: $os/$platform"
-    echo "    File: $file.$extension"
+    echo "Downloading FFI library for $os/$platform"
+    echo "    Destination: $path/$dest_file"
     echo "    URL: $url"
 
     echo -n "    Downloading... "
-    curl --silent -L "$url" -o "$path/$file.$extension.gz"
-    curl --silent -L "$sha" -o "$path/$file.$extension.gz.sha256"
+    curl --silent -L "$url" -o "$path/$dest_file"
+    curl --silent -L "$sha" -o "$path/$dest_file.sha256"
     echo "OK"
 
     echo -n "    Verifying... "
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # OSX requires an empty arg passed to -i, but this doesn't work on Lin/Win
-        sed -Ei '' "s|../target/artifacts/.+$|$path/$file.$extension.gz|" "$path/$file.$extension.gz.sha256"
-        shasum -a 256 --check --quiet "$path/$file.$extension.gz.sha256"
+        sed -Ei '' "s|../target/artifacts/.+$|$path/$dest_file|" "$path/$dest_file.sha256"
+        shasum -a 256 --check --quiet "$path/$dest_file.sha256"
     else
-        sed -Ei "s|../target/artifacts/.+$|$path/$file.$extension.gz|" "$path/$file.$extension.gz.sha256"
-        sha256sum --check --quiet "$path/$file.$extension.gz.sha256"
+        sed -Ei "s|../target/artifacts/.+$|$path/$dest_file|" "$path/$dest_file.sha256"
+        sha256sum --check --quiet "$path/$dest_file.sha256"
     fi
 
-    rm "$path/$file.$extension.gz.sha256"
+    rm "$path/$dest_file.sha256"
     echo "OK"
 
     echo -n "    Extracting... "
-    gunzip -f "$path/$file.$extension.gz"
+    gunzip -f "$path/$dest_file"
     echo "OK"
 }
 
-download_native "$MOCK_SERVER_BASE_URL" "pact_mock_server_ffi" "pact_mock_server_ffi" "windows" "x86_64" "dll"
-download_native "$MOCK_SERVER_BASE_URL" "pact_mock_server_ffi" "libpact_mock_server_ffi" "linux" "x86_64" "so"
-download_native "$MOCK_SERVER_BASE_URL" "pact_mock_server_ffi" "pact_mock_server_ffi" "osx" "x86_64" "dylib"
-
-download_native "$VERIFIER_BASE_URL" "pact_verifier_ffi" "pact_verifier_ffi" "windows" "x86_64" "dll"
-download_native "$VERIFIER_BASE_URL" "pact_verifier_ffi" "libpact_verifier_ffi" "linux" "x86_64" "so"
-download_native "$VERIFIER_BASE_URL" "pact_verifier_ffi" "pact_verifier_ffi" "osx" "x86_64" "dylib"
+download_native "pact_ffi" "windows" "x86_64" "dll"
+download_native "libpact_ffi" "linux" "x86_64" "so"
+download_native "libpact_ffi" "osx" "x86_64" "dylib"

--- a/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
+++ b/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
@@ -177,7 +177,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.3"
+      "version": "0.9.5"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/src/PactNet.Native/IMockServer.cs
+++ b/src/PactNet.Native/IMockServer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {

--- a/src/PactNet.Native/Interop/InteractionHandle.cs
+++ b/src/PactNet.Native/Interop/InteractionHandle.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PactNet.Native.Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal readonly struct InteractionHandle
+    {
+        public readonly UIntPtr Pact;
+        public readonly UIntPtr Interaction;
+    }
+}

--- a/src/PactNet.Native/Interop/InteractionPart.cs
+++ b/src/PactNet.Native/Interop/InteractionPart.cs
@@ -1,0 +1,8 @@
+namespace PactNet.Native.Interop
+{
+    internal enum InteractionPart
+    {
+        Request = 0,
+        Response = 1
+    }
+}

--- a/src/PactNet.Native/Interop/LevelFilter.cs
+++ b/src/PactNet.Native/Interop/LevelFilter.cs
@@ -1,0 +1,12 @@
+namespace PactNet.Native.Interop
+{
+    internal enum LevelFilter
+    {
+        Off = 0,
+        Error = 1,
+        Warn = 2,
+        Info = 3,
+        Debug = 4,
+        Trace = 5,
+    }
+}

--- a/src/PactNet.Native/Interop/NativeInterop.cs
+++ b/src/PactNet.Native/Interop/NativeInterop.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PactNet.Native.Interop
+{
+    /// <summary>
+    /// Interop definitions to the Pact FFI library
+    /// </summary>
+    internal static class NativeInterop
+    {
+        private const string dllName = "pact_ffi";
+
+        /// <summary>
+        /// Static initialiser for the Pact FFI library
+        /// </summary>
+        static NativeInterop()
+        {
+            // TODO: Make this configurable and specified by the user
+            LogToBuffer(LevelFilter.Debug);
+        }
+
+        [DllImport(dllName, EntryPoint = "pactffi_log_to_buffer")]
+        public static extern int LogToBuffer(LevelFilter levelFilter);
+
+        [DllImport(dllName, EntryPoint = "pactffi_create_mock_server_for_pact")]
+        public static extern int CreateMockServerForPact(PactHandle pact, string addrStr, bool tls);
+
+        [DllImport(dllName, EntryPoint = "pactffi_mock_server_mismatches")]
+        public static extern IntPtr MockServerMismatches(int mockServerPort);
+
+        [DllImport(dllName, EntryPoint = "pactffi_mock_server_logs")]
+        public static extern IntPtr MockServerLogs(int mockServerPort);
+
+        [DllImport(dllName, EntryPoint = "pactffi_cleanup_mock_server")]
+        public static extern bool CleanupMockServer(int mockServerPort);
+
+        [DllImport(dllName, EntryPoint = "pactffi_write_pact_file")]
+        public static extern int WritePactFile(int mockServerPort, string directory, bool overwrite);
+
+        [DllImport(dllName, EntryPoint = "pactffi_new_pact")]
+        public static extern PactHandle NewPact(string consumerName, string providerName);
+
+        [DllImport(dllName, EntryPoint = "pactffi_with_specification")]
+        public static extern bool WithSpecification(PactHandle pact, PactSpecification version);
+
+        [DllImport(dllName, EntryPoint = "pactffi_new_interaction")]
+        public static extern InteractionHandle NewInteraction(PactHandle pact, string description);
+
+        [DllImport(dllName, EntryPoint = "pactffi_given")]
+        public static extern bool Given(InteractionHandle interaction, string description);
+
+        [DllImport(dllName, EntryPoint = "pactffi_given_with_param")]
+        public static extern bool GivenWithParam(InteractionHandle interaction, string description, string name, string value);
+
+        [DllImport(dllName, EntryPoint = "pactffi_with_request")]
+        public static extern bool WithRequest(InteractionHandle interaction, string method, string path);
+
+        [DllImport(dllName, EntryPoint = "pactffi_with_query_parameter")]
+        public static extern bool WithQueryParameter(InteractionHandle interaction, string name, UIntPtr index, string value);
+
+        [DllImport(dllName, EntryPoint = "pactffi_with_header")]
+        public static extern bool WithHeader(InteractionHandle interaction, InteractionPart part, string name, UIntPtr index, string value);
+
+        [DllImport(dllName, EntryPoint = "pactffi_response_status")]
+        public static extern bool ResponseStatus(InteractionHandle interaction, ushort status);
+
+        [DllImport(dllName, EntryPoint = "pactffi_with_body")]
+        public static extern bool WithBody(InteractionHandle interaction, InteractionPart part, string contentType, string body);
+
+        [DllImport(dllName, EntryPoint = "pactffi_free_string")]
+        public static extern void FreeString(IntPtr s);
+
+        [DllImport(dllName, EntryPoint = "pactffi_verify")]
+        public static extern int Verify(string args);
+    }
+}

--- a/src/PactNet.Native/Interop/PactHandle.cs
+++ b/src/PactNet.Native/Interop/PactHandle.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PactNet.Native.Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal readonly struct PactHandle
+    {
+        public readonly UIntPtr Pact;
+    }
+}

--- a/src/PactNet.Native/Interop/PactSpecification.cs
+++ b/src/PactNet.Native/Interop/PactSpecification.cs
@@ -1,0 +1,12 @@
+namespace PactNet.Native.Interop
+{
+    internal enum PactSpecification
+    {
+        Unknown = 0,
+        V1 = 1,
+        V1_1 = 2,
+        V2 = 3,
+        V3 = 4,
+        V4 = 5
+    }
+}

--- a/src/PactNet.Native/NativePactBuilder.cs
+++ b/src/PactNet.Native/NativePactBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using PactNet.Models;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {

--- a/src/PactNet.Native/NativePactVerifier.cs
+++ b/src/PactNet.Native/NativePactVerifier.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Runtime.InteropServices;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {
@@ -9,22 +8,12 @@ namespace PactNet.Native
     internal class NativePactVerifier : IVerifierProvider
     {
         /// <summary>
-        /// Static constructor for <see cref="NativePactVerifier"/>
-        /// </summary>
-        static NativePactVerifier()
-        {
-            // TODO: make this configurable somehow, except it applies once for the entire native lifetime, so dunno
-            Environment.SetEnvironmentVariable("LOG_LEVEL", "DEBUG");
-            Interop.Init("LOG_LEVEL");
-        }
-
-        /// <summary>
         /// Verify the pact from the given args
         /// </summary>
         /// <param name="args">Verifier args</param>
         public void Verify(string args)
         {
-            int result = Interop.Verify(args);
+            int result = NativeInterop.Verify(args);
 
             if (result == 0)
             {
@@ -39,23 +28,6 @@ namespace PactNet.Native
                 4 => new PactFailureException("Invalid arguments were provided to the verification process"),
                 _ => new PactFailureException($"An unknown error occurred with error code {result}")
             };
-        }
-
-        /// <summary>
-        /// P/Invoke bondings to the pact verifier FFI library
-        /// </summary>
-        private static class Interop
-        {
-            private const string dllName = "pact_verifier_ffi";
-
-            [DllImport(dllName, EntryPoint = "init")]
-            public static extern void Init(string logEnvVar);
-
-            [DllImport(dllName, EntryPoint = "free_string")]
-            public static extern void FreeString(string s);
-
-            [DllImport(dllName, EntryPoint = "verify")]
-            public static extern int Verify(string args);
         }
     }
 }

--- a/src/PactNet.Native/NativeRequestBuilder.cs
+++ b/src/PactNet.Native/NativeRequestBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Newtonsoft.Json;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {

--- a/src/PactNet.Native/NativeResponseBuilder.cs
+++ b/src/PactNet.Native/NativeResponseBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using Newtonsoft.Json;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {

--- a/src/PactNet.Native/PactExtensions.cs
+++ b/src/PactNet.Native/PactExtensions.cs
@@ -1,4 +1,5 @@
 using PactNet.Models;
+using PactNet.Native.Interop;
 
 namespace PactNet.Native
 {

--- a/src/PactNet.Native/PactNet.Native.csproj
+++ b/src/PactNet.Native/PactNet.Native.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
@@ -42,49 +42,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_mock_server_ffi.dll">
-      <Link>pact_mock_server_ffi.dll</Link>
+    <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_ffi.dll">
+      <Link>pact_ffi.dll</Link>
       <PackagePath>runtimes/win-x64/native</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory Condition="'$(IsWindows)'">PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_verifier_ffi.dll">
-      <Link>pact_verifier_ffi.dll</Link>
-      <PackagePath>runtimes/win-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsWindows)'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64\libpact_mock_server_ffi.so">
-      <Link>libpact_mock_server_ffi.so</Link>
+    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64\libpact_ffi.so">
+      <Link>libpact_ffi.so</Link>
       <PackagePath>runtimes/linux-x64/native</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory Condition="'$(IsLinux)'">PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64\libpact_verifier_ffi.so">
-      <Link>libpact_verifier_ffi.so</Link>
-      <PackagePath>runtimes/linux-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsLinux)'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\osx\x86_64\pact_mock_server_ffi.dylib">
-      <Link>pact_mock_server_ffi.dylib</Link>
-      <PackagePath>runtimes/osx-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsOSX)'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\osx\x86_64\pact_verifier_ffi.dylib">
-      <Link>pact_verifier_ffi.dylib</Link>
+    <Content Include="$(MSBuildProjectDirectory)\..\..\build\osx\x86_64\libpact_ffi.dylib">
+      <Link>libpact_ffi.dylib</Link>
       <PackagePath>runtimes/osx-x64/native</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory Condition="'$(IsOSX)'">PreserveNewest</CopyToOutputDirectory>

--- a/tests/PactNet.Native.Tests/NativeMockServerTests.cs
+++ b/tests/PactNet.Native.Tests/NativeMockServerTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using PactNet.Native.Interop;
 using Xunit;
 
 namespace PactNet.Native.Tests

--- a/tests/PactNet.Native.Tests/NativePactBuilderTests.cs
+++ b/tests/PactNet.Native.Tests/NativePactBuilderTests.cs
@@ -4,6 +4,7 @@ using AutoFixture;
 using FluentAssertions;
 using Moq;
 using PactNet.Infrastructure.Outputters;
+using PactNet.Native.Interop;
 using Xunit;
 
 namespace PactNet.Native.Tests

--- a/tests/PactNet.Native.Tests/NativeRequestBuilderTests.cs
+++ b/tests/PactNet.Native.Tests/NativeRequestBuilderTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using PactNet.Native.Interop;
 using Xunit;
 
 namespace PactNet.Native.Tests

--- a/tests/PactNet.Native.Tests/NativeResponseBuilderTests.cs
+++ b/tests/PactNet.Native.Tests/NativeResponseBuilderTests.cs
@@ -1,8 +1,9 @@
-﻿using System.Net;
+using System.Net;
 using AutoFixture;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using PactNet.Native.Interop;
 using Xunit;
 
 namespace PactNet.Native.Tests

--- a/tests/PactNet.Native.Tests/data/v2-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v2-consumer-integration.json
@@ -74,7 +74,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.3"
+      "version": "0.9.5"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/tests/PactNet.Native.Tests/data/v3-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-consumer-integration.json
@@ -132,7 +132,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.3"
+      "version": "0.9.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Native.Tests/data/v3-server-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-server-integration.json
@@ -46,7 +46,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.3"
+      "version": "0.9.5"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
I've moved the consumer and verifier interop definitions into a single file to make it obvious that the library itself is now a single thing, but maintained the separate interfaces/classes to encapsulate the logic required in each (such as handing the int error codes that you get back from some calls).