### PR TITLE
fix!: JSON message content respects default serialisation settings

### DIFF
--- a/samples/EventImporter/Consumer.Tests/EventImporterTests.cs
+++ b/samples/EventImporter/Consumer.Tests/EventImporterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Consumer.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -32,12 +33,12 @@ namespace Consumer.Tests
                 new XUnitOutput(output)
             };
 
-            IMessagePactV3 v3 = MessagePact.V3("Event API Consumer V3 Message", "Event API V3 Message", config);
+            IMessagePactV3 v3 = MessagePact.V3("Event API Consumer V3 Message", "Event API V3 Message", this.config);
             this.messagePact = v3.UsingNativeBackend();
         }
 
         [Fact]
-        public void GetAllEvents_FromQueue_Should_CreatePact_WithMessages()
+        public async Task GetAllEvents_FromQueue_Should_CreatePact_WithMessages()
         {
             var worker = new EventsWorker(new FakeEventProcessor());
 
@@ -45,10 +46,11 @@ namespace Consumer.Tests
                 .ExpectsToReceive("receiving events from the queue")
                 .Given("A list of events is pushed to the queue")
                 .WithMetadata("key", "valueKey")
-                .WithContent(
-                    Match.MinType(new List<dynamic>
+                .WithJsonContent(
+                    Match.MinType(new[]
                     {
-                        new {
+                        new
+                        {
                             EventId = Match.Regex(Guid.Parse("45D80D13-D5A2-48D7-8353-CBB4C0EAABF5").ToString(),
                                 "(^([0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$)"),
                             Timestamp = Match.Type(DateTime.Parse("2014-06-30T01:37:41.0660548")),
@@ -56,7 +58,7 @@ namespace Consumer.Tests
                         }
                     }, 1));
 
-            this.messagePact.VerifyAsync<List<Event>>(async events => await worker.ProcessMessages(events));
+            await this.messagePact.VerifyAsync<List<Event>>(events => worker.ProcessMessages(events));
         }
     }
 }

--- a/samples/EventImporter/Consumer/EventsWorker.cs
+++ b/samples/EventImporter/Consumer/EventsWorker.cs
@@ -23,6 +23,7 @@ namespace Consumer
             }
 
             var operationSuccessful = true;
+
             foreach (var @event in events)
             {
                 operationSuccessful = await _eventHandler.ProcessEvent(@event);

--- a/src/PactNet.Native/IMessageMockServer.cs
+++ b/src/PactNet.Native/IMessageMockServer.cs
@@ -88,7 +88,7 @@ namespace PactNet.Native
         bool WithContents(MessageHandle message, string contentType, string body, uint size);
 
         /// <summary>
-        /// returns the message without the matchers
+        /// Returns the message without the matchers
         /// </summary>
         /// <param name="message">message</param>
         /// <returns>Success</returns>

--- a/src/PactNet.Native/NativeMessagePactBuilder.cs
+++ b/src/PactNet.Native/NativeMessagePactBuilder.cs
@@ -51,11 +51,11 @@ namespace PactNet.Native
         /// <returns>Fluent builder</returns>
         internal IMessageBuilderV3 ExpectsToReceive(string description)
         {
-            this.message = this.server.NewMessage(pact, description);
+            this.message = this.server.NewMessage(this.pact, description);
 
             this.server.ExpectsToReceive(this.message, description);
 
-            return new NativeMessageBuilder(this.server, this.message);
+            return new NativeMessageBuilder(this.server, this.message, this.config.DefaultJsonSettings);
         }
 
         /// <summary>
@@ -80,18 +80,19 @@ namespace PactNet.Native
         {
             try
             {
-                var content = JsonConvert.DeserializeObject<NativeMessage>(this.server.Reify(message));
+                string reified = this.server.Reify(this.message);
+                NativeMessage content = JsonConvert.DeserializeObject<NativeMessage>(reified);
 
-                var messageReified = JsonConvert.DeserializeObject<T>(content.Contents.ToString());
+                T messageReified = JsonConvert.DeserializeObject<T>(content.Contents.ToString());
 
                 handler(messageReified);
 
-                this.server.WriteMessagePactFile(pact, config.PactDir, false);
+                this.server.WriteMessagePactFile(this.pact, this.config.PactDir, false);
             }
             catch (Exception e)
             {
                 throw new PactMessageConsumerVerificationException(
-                    $"The message {message} could not be verified by the consumer handler", e);
+                    $"The message {this.message} could not be verified by the consumer handler", e);
             }
         }
 
@@ -103,18 +104,18 @@ namespace PactNet.Native
         {
             try
             {
-                var content = JsonConvert.DeserializeObject<NativeMessage>(this.server.Reify(message));
+                string reified = this.server.Reify(this.message);
+                NativeMessage content = JsonConvert.DeserializeObject<NativeMessage>(reified);
 
-                var messageReified = JsonConvert.DeserializeObject<T>(content.Contents.ToString());
+                T messageReified = JsonConvert.DeserializeObject<T>(content.Contents.ToString());
 
                 await handler(messageReified);
 
-                this.server.WriteMessagePactFile(pact, config.PactDir, false);
+                this.server.WriteMessagePactFile(this.pact, this.config.PactDir, false);
             }
             catch (Exception e)
             {
-                throw new PactMessageConsumerVerificationException(
-                    $"The message {message} could not be verified by the consumer handler", e);
+                throw new PactMessageConsumerVerificationException($"The message {this.message} could not be verified by the consumer handler", e);
             }
         }
 

--- a/src/PactNet/Exceptions/PactFailureException.cs
+++ b/src/PactNet/Exceptions/PactFailureException.cs
@@ -2,10 +2,27 @@ using System;
 
 namespace PactNet.Exceptions
 {
+    /// <summary>
+    /// Error relating to a failing pact test
+    /// </summary>
+    [Serializable]
     public class PactFailureException : Exception
     {
+        /// <summary>
+        /// Initialises a new instance of the <see cref="PactFailureException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error</param>
         public PactFailureException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="PactFailureException" /> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified</param>
+        public PactFailureException(string message, Exception innerException) : base(message, innerException)
         {
         }
     }

--- a/src/PactNet/Exceptions/PactMessageConsumerVerificationException.cs
+++ b/src/PactNet/Exceptions/PactMessageConsumerVerificationException.cs
@@ -3,10 +3,10 @@ using System;
 namespace PactNet.Exceptions
 {
     /// <summary>
-    /// Defines the messagePact message consumer verification exception
+    /// Error related to verifying a message pact consumer test
     /// </summary>
     [Serializable]
-    public class PactMessageConsumerVerificationException : Exception
+    public class PactMessageConsumerVerificationException : PactFailureException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PactMessageConsumerVerificationException" /> class

--- a/src/PactNet/IMessageBuilder.cs
+++ b/src/PactNet/IMessageBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace PactNet
 {
@@ -31,10 +32,18 @@ namespace PactNet
         IMessageBuilderV3 WithMetadata(string key, string value);
 
         /// <summary>
-        /// Set the content
+        /// Set message content which is serialised as JSON
         /// </summary>
-        /// <param name="content">Dynamic content</param>
+        /// <param name="body">Message body</param>
         /// <returns>Fluent builder</returns>
-        IMessageBuilderV3 WithContent(dynamic content);
+        IMessageBuilderV3 WithJsonContent(dynamic body);
+
+        /// <summary>
+        /// Set message content which is serialised as JSON
+        /// </summary>
+        /// <param name="body">Message body</param>
+        /// <param name="settings">Custom JSON serializer settings</param>
+        /// <returns>Fluent builder</returns>
+        IMessageBuilderV3 WithJsonContent(dynamic body, JsonSerializerSettings settings);
     }
 }

--- a/src/PactNet/PactConfig.cs
+++ b/src/PactNet/PactConfig.cs
@@ -5,22 +5,35 @@ using PactNet.Infrastructure.Outputters;
 
 namespace PactNet
 {
+    /// <summary>
+    /// Pact configuration
+    /// </summary>
     public class PactConfig
     {
         private string _pactDir;
+        private string _logDir;
+
+        /// <summary>
+        /// Pact file destination directory
+        /// </summary>
         public string PactDir
         {
             get { return _pactDir; }
             set { _pactDir = ConvertToDirectory(value); }
         }
 
-        private string _logDir;
+        /// <summary>
+        /// Log file destination directory
+        /// </summary>
         public string LogDir
         {
             get { return _logDir; }
             set { _logDir = ConvertToDirectory(value); }
         }
 
+        /// <summary>
+        /// Log outputs
+        /// </summary>
         public IEnumerable<IOutput> Outputters { get; set; } = new List<IOutput>
         {
             new ConsoleOutput()
@@ -31,12 +44,20 @@ namespace PactNet
         /// </summary>
         public JsonSerializerSettings DefaultJsonSettings { get; set; } = new JsonSerializerSettings();
 
+        /// <summary>
+        /// Initialises a new instance of the <see cref="PactConfig"/> class.
+        /// </summary>
         public PactConfig()
         {
-            PactDir = Constants.DefaultPactDir;
-            LogDir = Constants.DefaultLogDir;
+            this.PactDir = Constants.DefaultPactDir;
+            this.LogDir = Constants.DefaultLogDir;
         }
 
+        /// <summary>
+        /// Ensure a string path ends with a trailing slash
+        /// </summary>
+        /// <param name="path">Directory path</param>
+        /// <returns>Path with trailing slash</returns>
         private static string ConvertToDirectory(string path)
         {
             if (!path.EndsWith("/") && !path.EndsWith("\\"))

--- a/tests/PactNet.Native.Tests/NativePactMessageBuilderTests.cs
+++ b/tests/PactNet.Native.Tests/NativePactMessageBuilderTests.cs
@@ -76,7 +76,7 @@ namespace PactNet.Native.Tests
             var content = new MessageModel { Id = 1, Description = "description" };
             this.messagePact
                 .ExpectsToReceive("a description")
-                .WithContent(content);
+                .WithJsonContent(content);
 
             SetServerReifyMessage(JsonConvert.SerializeObject(content.ToNativeMessage()));
 

--- a/tests/PactNet.Native.Tests/PactExtensionsTests.cs
+++ b/tests/PactNet.Native.Tests/PactExtensionsTests.cs
@@ -156,7 +156,7 @@ namespace PactNet.Native.Tests
                     ["baz"] = "bash"
                 })
                 .WithMetadata("queueId", "1234")
-                .WithContent(new TestData { Int = 1, String = "a description" });
+                .WithJsonContent(new TestData { Int = 1, String = "a description" });
 
             builder.Verify<TestData>(_ => { });
 

--- a/tests/PactNet.Native.Tests/data/v3-message-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-message-consumer-integration.json
@@ -5,9 +5,9 @@
   "messages": [
     {
       "contents": {
-        "Bool": false,
-        "Int": 1,
-        "String": "a description"
+        "bool": false,
+        "int": 1,
+        "string": "a description"
       },
       "description": "a sample request",
       "metadata": {


### PR DESCRIPTION
Fix message pact consumer bodies not respecting default serialisation settings, and add option for providing custom serialiser settings on a per-message basis (to be consistent with the request/response pacts).