### PR TITLE
feat: Enable configuring provider log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ build/tools/
 build/linux/
 build/osx/
 build/windows/
+
+samples/ReadMe/Provider.Tests/Properties/launchSettings.json
+samples/ReadMe/Provider/Properties/launchSettings.json
+

--- a/src/PactNet.Native/PactVerifier.cs
+++ b/src/PactNet.Native/PactVerifier.cs
@@ -224,14 +224,34 @@ namespace PactNet.Native
         }
 
         /// <summary>
+        /// Alter the log level from the default value
+        /// </summary>
+        /// <param name="level">Log level</param>
+        /// <returns>Fluent builder</returns>
+        public IPactVerifier WithLogLevel(PactLogLevel level)
+        {
+            string arg = level switch
+            {
+                PactLogLevel.Trace => "trace",
+                PactLogLevel.Debug => "debug",
+                PactLogLevel.Information => "info",
+                PactLogLevel.Warn => "warn",
+                PactLogLevel.Error => "error",
+                PactLogLevel.None => "none",
+                _ => throw new ArgumentOutOfRangeException(nameof(level), level, "Unsupported log level")
+            };
+
+            this.verifierArgs.Add("--loglevel");
+            this.verifierArgs.Add(arg);
+
+            return this;
+        }
+
+        /// <summary>
         /// Verify provider interactions
         /// </summary>
         public void Verify()
         {
-            // TODO: make verifier log level configurable
-            this.verifierArgs.Add("--loglevel");
-            this.verifierArgs.Add("trace");
-
             string formatted = string.Join(Environment.NewLine, this.verifierArgs);
 
             this.config.WriteLine("Invoking the pact verifier with args:");

--- a/src/PactNet/IPactVerifier.cs
+++ b/src/PactNet/IPactVerifier.cs
@@ -77,6 +77,13 @@ namespace PactNet
         IPactVerifier WithPublishedResults(string providerVersion, IEnumerable<string> providerTags = null);
 
         /// <summary>
+        /// Alter the log level from the default value
+        /// </summary>
+        /// <param name="level">Log level</param>
+        /// <returns>Fluent builder</returns>
+        IPactVerifier WithLogLevel(PactLogLevel level);
+
+        /// <summary>
         /// Verify provider interactions
         /// </summary>
         void Verify();

--- a/src/PactNet/LogLevel.cs
+++ b/src/PactNet/LogLevel.cs
@@ -1,0 +1,15 @@
+namespace PactNet
+{
+    /// <summary>
+    /// Pact log level
+    /// </summary>
+    public enum PactLogLevel
+    {
+        Trace,
+        Debug,
+        Information,
+        Warn,
+        Error,
+        None
+    }
+}

--- a/tests/PactNet.Native.Tests/PactVerifierTests.cs
+++ b/tests/PactNet.Native.Tests/PactVerifierTests.cs
@@ -154,14 +154,25 @@ namespace PactNet.Native.Tests
                            "--provider-tags", "feature/branch,production");
         }
 
+        [Theory]
+        [InlineData(PactLogLevel.Trace,       "trace")]
+        [InlineData(PactLogLevel.Debug,       "debug")]
+        [InlineData(PactLogLevel.Information, "info")]
+        [InlineData(PactLogLevel.Warn,        "warn")]
+        [InlineData(PactLogLevel.Error,       "error")]
+        [InlineData(PactLogLevel.None,        "none")]
+        public void WithLogLevel_WhenCalled_AddsLogLevelArg(PactLogLevel level, string expected)
+        {
+            this.verifier.WithLogLevel(level);
+
+            this.CheckArgs("--loglevel", expected);
+        }
+
         private void CheckArgs(params string[] args)
         {
             this.verifier.Verify();
 
             string formatted = string.Join(Environment.NewLine, args);
-
-            // log level is fixed at the moment and always included
-            formatted = string.Join(Environment.NewLine, formatted, "--loglevel", "trace");
 
             this.mockProvider.Verify(v => v.Verify(formatted));
         }


### PR DESCRIPTION
Allow the log level to be set to something other than `trace`