### PR TITLE
WIP feat: Add verifier logs to output (#314)

### DIFF
--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FFI_VERSION="0.0.0"
+FFI_VERSION="0.0.3"
 FFI_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$FFI_VERSION"
 
 GREEN="\e[32m"

--- a/src/PactNet.Native/Interop/NativeInterop.cs
+++ b/src/PactNet.Native/Interop/NativeInterop.cs
@@ -75,6 +75,9 @@ namespace PactNet.Native.Interop
         [DllImport(dllName, EntryPoint = "pactffi_verify")]
         public static extern int Verify(string args);
 
+        [DllImport(dllName, EntryPoint = "pactffi_verifier_logs_for_provider")]
+        public static extern IntPtr VerifierLogsForProvider(string provider);
+
         #endregion Http Interop Support
 
         #region Messaging Interop Support

--- a/src/PactNet.Native/Verifier/IVerifierProvider.cs
+++ b/src/PactNet.Native/Verifier/IVerifierProvider.cs
@@ -9,6 +9,14 @@ namespace PactNet.Native.Verifier
         /// Verify the pact from the given args
         /// </summary>
         /// <param name="args">Verifier args</param>
-        void Verify(string args);
+        /// <returns>Verifier result</returns>
+        PactVerifierResult Verify(string args);
+
+        /// <summary>
+        /// Get the logs for the current verification run
+        /// </summary>
+        /// <param name="provider">Name of the provider</param>
+        /// <returns>Verifier logs</returns>
+        string VerifierLogs(string provider);
     }
 }

--- a/src/PactNet.Native/Verifier/PactVerifierResult.cs
+++ b/src/PactNet.Native/Verifier/PactVerifierResult.cs
@@ -1,0 +1,38 @@
+namespace PactNet.Native.Verifier
+{
+    /// <summary>
+    /// Pact verification result
+    /// </summary>
+    internal enum PactVerifierResult
+    {
+        /// <summary>
+        /// An unknown error has occurred
+        /// </summary>
+        UnknownError = -1,
+
+        /// <summary>
+        /// Pact verifier succeeded
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// Pact verification failed
+        /// </summary>
+        Failure,
+
+        /// <summary>
+        /// A null pointer was passed to the verifier
+        /// </summary>
+        NullPointer,
+
+        /// <summary>
+        /// The verifier panicked
+        /// </summary>
+        Panic,
+
+        /// <summary>
+        /// Invalid arguments were provided to the verifier
+        /// </summary>
+        InvalidArguments,
+    }
+}

--- a/tests/PactNet.Native.Tests/Verifier/NativePactVerifierPairTests.cs
+++ b/tests/PactNet.Native.Tests/Verifier/NativePactVerifierPairTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Moq;
+using PactNet.Exceptions;
+using PactNet.Infrastructure.Outputters;
 using PactNet.Native.Verifier;
 using PactNet.Verifier;
 using Xunit;
@@ -11,23 +14,34 @@ namespace PactNet.Native.Tests.Verifier
 {
     public class NativePactVerifierPairTests
     {
+        private const string ProviderName = "provider";
+
         private readonly NativePactVerifierPair verifier;
 
         private readonly Mock<IVerifierProvider> mockProvider;
+        private readonly Mock<IOutput> mockOutput;
 
         private readonly IDictionary<string, string> verifierArgs;
 
         public NativePactVerifierPairTests(ITestOutputHelper output)
         {
             this.mockProvider = new Mock<IVerifierProvider>();
+            this.mockProvider.Setup(p => p.Verify(It.IsAny<string>())).Returns(PactVerifierResult.Success);
+            this.mockProvider.Setup(p => p.VerifierLogs(It.IsAny<string>())).Returns(string.Empty);
 
-            this.verifierArgs = new Dictionary<string, string>();
+            this.mockOutput = new Mock<IOutput>();
+
+            this.verifierArgs = new Dictionary<string, string>
+            {
+                ["--provider-name"] = ProviderName
+            };
 
             var config = new PactVerifierConfig
             {
                 Outputters = new[]
                 {
-                    new XUnitOutput(output)
+                    new XUnitOutput(output),
+                    this.mockOutput.Object
                 }
             };
 
@@ -83,8 +97,56 @@ namespace PactNet.Native.Tests.Verifier
             this.CheckArgs("--foo", "--bar", "--baz");
         }
 
+        [Fact]
+        public void Verify_Success_DoesNotThrow()
+        {
+            this.mockProvider.Setup(p => p.Verify(It.IsAny<string>())).Returns(PactVerifierResult.Success);
+
+            Action action = () => this.verifier.Verify();
+
+            action.Should().NotThrow("because the verification succeeded");
+        }
+
+        [Theory]
+        [InlineData(PactVerifierResult.InvalidArguments)]
+        [InlineData(PactVerifierResult.Failure)]
+        [InlineData(PactVerifierResult.NullPointer)]
+        [InlineData(PactVerifierResult.Panic)]
+        [InlineData(PactVerifierResult.UnknownError)]
+        internal void Verify_Error_ThrowsPactFailureException(PactVerifierResult result)
+        {
+            this.mockProvider.Setup(p => p.Verify(It.IsAny<string>())).Returns(result);
+
+            Action action = () => this.verifier.Verify();
+
+            action.Should().Throw<PactFailureException>();
+        }
+
+        [Fact]
+        public void Verify_UnexpectedResult_ThrowsArgumentOutOfRangeException()
+        {
+            this.mockProvider.Setup(p => p.Verify(It.IsAny<string>())).Returns((PactVerifierResult)12345);
+
+            Action action = () => this.verifier.Verify();
+
+            action.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void Verify_WhenCalled_AddsLogsToOutput()
+        {
+            const string expected = "logs";
+            this.mockProvider.Setup(p => p.VerifierLogs(ProviderName)).Returns(expected);
+
+            this.verifier.Verify();
+
+            this.mockOutput.Verify(o => o.WriteLine(expected));
+        }
+
         private void CheckArgs(params string[] args)
         {
+            args = new[] { "--provider-name", ProviderName }.Concat(args).ToArray();
+
             this.verifier.Verify();
 
             string formatted = string.Join(Environment.NewLine, args);

--- a/tests/PactNet.Native.Tests/data/v2-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v2-consumer-integration.json
@@ -74,7 +74,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "version": "0.1.3"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/tests/PactNet.Native.Tests/data/v3-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-consumer-integration.json
@@ -132,7 +132,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "version": "0.1.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Native.Tests/data/v3-message-consumer-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-message-consumer-integration.json
@@ -36,7 +36,7 @@
       "language": "C#"
     },
     "pactRust": {
-      "version": "0.9.5"
+      "version": "0.1.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Native.Tests/data/v3-server-integration.json
+++ b/tests/PactNet.Native.Tests/data/v3-server-integration.json
@@ -46,7 +46,7 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "version": "0.1.3"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
Adds verifier logs from FFI to verifier output.

NOTE: This is currently broken on Windows because of an issue in the FFI: https://github.com/pact-foundation/pact-reference/issues/156. Once that issue is fixed we can bump the FFI version and this should be ready to merge

EDIT: It appears another FFI issue is also making the integration tests fail: https://github.com/pact-foundation/pact-reference/issues/157. Hopefully both issues will be fixed in the same FFI upgrade