### PR TITLE
chore: Upgrade to FFI 0.1.6

### DIFF
--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FFI_VERSION="0.0.0"
+FFI_VERSION="0.1.6"
 FFI_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$FFI_VERSION"
 
 GREEN="\e[32m"

--- a/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -254,7 +254,7 @@ namespace Consumer.Tests
             {
                 EventId = Guid.Parse("83F9262F-28F1-4703-AB1A-8CFD9E8249C9"),
                 EventType = "DetailsView",
-                Timestamp = DateTime.UtcNow
+                Timestamp = 27.June(2014).At(23, 51, 12).AsUtc()
             };
 
             this.pact

--- a/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
+++ b/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
@@ -129,7 +129,7 @@
         "body": {
           "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
           "eventType": "DetailsView",
-          "timestamp": "2021-06-04T14:59:07.8971463Z"
+          "timestamp": "2014-06-27T23:51:12.0000000Z"
         },
         "headers": {
           "content-type": "application/json; charset=utf-8"
@@ -177,7 +177,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "mockserver": "0.8.7",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/samples/EventImporter/Consumer.Tests/pacts/Event API Consumer V3 Message-Event API V3 Message.json
+++ b/samples/EventImporter/Consumer.Tests/pacts/Event API Consumer V3 Message-Event API V3 Message.json
@@ -63,7 +63,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/samples/ReadMe/pacts/Something API Consumer-Something API.json
+++ b/samples/ReadMe/pacts/Something API Consumer-Something API.json
@@ -32,7 +32,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "mockserver": "0.8.7",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/src/PactNet.AspNetCore/Messaging/MessageMiddleware.cs
+++ b/src/PactNet.AspNetCore/Messaging/MessageMiddleware.cs
@@ -95,13 +95,14 @@ namespace PactNet.AspNetCore.Messaging
         /// <param name="context">the http context</param>
         /// <param name="metadata">the metadata</param>
         /// <param name="settings">JSON settings</param>
+        /// <seealso cref="https://github.com/pact-foundation/pact-reference/tree/master/rust/pact_verifier_cli#verifying-metadata" />
         private static void AddMetadataToResponse(HttpContext context, dynamic metadata, JsonSerializerSettings settings)
         {
             string stringifyMetadata = JsonConvert.SerializeObject(metadata, settings);
             string metadataBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(stringifyMetadata));
 
             context.Response.ContentType = "application/json";
-            context.Response.Headers.Add("PACT_MESSAGE_METADATA", metadataBase64);
+            context.Response.Headers.Add("Pact-Message-Metadata", metadataBase64);
         }
 
         /// <summary>

--- a/src/PactNet/Interop/InteractionHandle.cs
+++ b/src/PactNet/Interop/InteractionHandle.cs
@@ -6,7 +6,6 @@ namespace PactNet.Interop
     [StructLayout(LayoutKind.Sequential)]
     internal readonly struct InteractionHandle
     {
-        public readonly UIntPtr Pact;
-        public readonly UIntPtr Interaction;
+        public readonly UIntPtr InteractionRef;
     }
 }

--- a/src/PactNet/Interop/MessageHandle.cs
+++ b/src/PactNet/Interop/MessageHandle.cs
@@ -6,7 +6,6 @@ namespace PactNet.Interop
     [StructLayout(LayoutKind.Sequential)]
     internal readonly struct MessageHandle
     {
-        public readonly UIntPtr Pact;
-        public readonly UIntPtr Interaction;
+        public readonly UIntPtr InteractionRef;
     }
 }

--- a/src/PactNet/Interop/MessagePactHandle.cs
+++ b/src/PactNet/Interop/MessagePactHandle.cs
@@ -6,6 +6,6 @@ namespace PactNet.Interop
     [StructLayout(LayoutKind.Sequential)]
     internal readonly struct MessagePactHandle
     {
-        public readonly UIntPtr Pact;
+        public readonly UIntPtr PactRef;
     }
 }

--- a/src/PactNet/Interop/PactHandle.cs
+++ b/src/PactNet/Interop/PactHandle.cs
@@ -6,6 +6,6 @@ namespace PactNet.Interop
     [StructLayout(LayoutKind.Sequential)]
     internal readonly struct PactHandle
     {
-        public readonly UIntPtr Pact;
+        public readonly UIntPtr PactRef;
     }
 }

--- a/tests/PactNet.Tests/data/v2-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v2-consumer-integration.json
@@ -74,7 +74,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "mockserver": "0.8.7",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/tests/PactNet.Tests/data/v3-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v3-consumer-integration.json
@@ -132,7 +132,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "mockserver": "0.8.7",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v3-message-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v3-message-consumer-integration.json
@@ -36,7 +36,8 @@
       "language": "C#"
     },
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v3-server-integration.json
+++ b/tests/PactNet.Tests/data/v3-server-integration.json
@@ -46,7 +46,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "version": "0.9.5"
+      "ffi": "0.1.6",
+      "mockserver": "0.8.7",
+      "models": "0.2.7"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
This is in preparation for replacing the existing verifier approach with a number of command-line style arguments with a proper handles approach, with the aim to introduce verifier logging.