### PR TITLE
feat: Allow setting JSON options in message interactions

### DIFF
--- a/samples/EventImporter/Consumer.Tests/pacts/Event API Consumer V3 Message-Event API V3 Message.json
+++ b/samples/EventImporter/Consumer.Tests/pacts/Event API Consumer V3 Message-Event API V3 Message.json
@@ -6,15 +6,24 @@
     {
       "contents": [
         {
-          "EventId": "45d80d13-d5a2-48d7-8353-cbb4c0eaabf5",
-          "EventType": "SearchView",
-          "Timestamp": "2014-06-30T01:37:41.0660548"
+          "eventId": "45d80d13-d5a2-48d7-8353-cbb4c0eaabf5",
+          "eventType": "SearchView",
+          "timestamp": "2014-06-30T01:37:41.0660548"
         }
       ],
       "description": "receiving events from the queue",
       "matchingRules": {
         "body": {
-          "$[0].EventId": {
+          "$": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type",
+                "min": 1
+              }
+            ]
+          },
+          "$[*].eventId": {
             "combine": "AND",
             "matchers": [
               {
@@ -23,7 +32,7 @@
               }
             ]
           },
-          "$[0].EventType": {
+          "$[*].eventType": {
             "combine": "AND",
             "matchers": [
               {
@@ -31,7 +40,7 @@
               }
             ]
           },
-          "$[0].Timestamp": {
+          "$[*].timestamp": {
             "combine": "AND",
             "matchers": [
               {
@@ -42,6 +51,7 @@
         }
       },
       "metadata": {
+        "contentType": "application/json",
         "key": "valueKey"
       },
       "providerStates": [

--- a/samples/EventImporter/Provider.Tests/TestStartup.cs
+++ b/samples/EventImporter/Provider.Tests/TestStartup.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using PactNet.AspNetCore.Messaging;
 
 namespace Provider.Tests
@@ -23,6 +25,10 @@ namespace Provider.Tests
             services.AddPactMessaging(options =>
             {
                 options.BasePath = "/pact-messages";
+                options.DefaultJsonSettings = new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver()
+                };
             });
 
             this.inner.ConfigureServices(services);

--- a/src/PactNet.AspNetCore/Messaging/MessageMiddleware.cs
+++ b/src/PactNet.AspNetCore/Messaging/MessageMiddleware.cs
@@ -71,10 +71,10 @@ namespace PactNet.AspNetCore.Messaging
 
             if (scenario.Metadata != null)
             {
-                AddMetadataToResponse(context, scenario.Metadata);
+                AddMetadataToResponse(context, scenario.Metadata, this.options.DefaultJsonSettings);
             }
 
-            await WriteToResponseAsync(context, response);
+            await WriteToResponseAsync(context, response, this.options.DefaultJsonSettings);
         }
 
         /// <summary>
@@ -82,9 +82,10 @@ namespace PactNet.AspNetCore.Messaging
         /// </summary>
         /// <param name="context">the http context</param>
         /// <param name="response">the dynamic message</param>
-        private static Task WriteToResponseAsync(HttpContext context, dynamic response)
+        /// <param name="settings">JSON settings</param>
+        private static Task WriteToResponseAsync(HttpContext context, dynamic response, JsonSerializerSettings settings)
         {
-            string responseBody = JsonConvert.SerializeObject(response);
+            string responseBody = JsonConvert.SerializeObject(response, settings);
             return context.Response.WriteAsync(responseBody);
         }
 
@@ -93,9 +94,10 @@ namespace PactNet.AspNetCore.Messaging
         /// </summary>
         /// <param name="context">the http context</param>
         /// <param name="metadata">the metadata</param>
-        private static void AddMetadataToResponse(HttpContext context, dynamic metadata)
+        /// <param name="settings">JSON settings</param>
+        private static void AddMetadataToResponse(HttpContext context, dynamic metadata, JsonSerializerSettings settings)
         {
-            string stringifyMetadata = JsonConvert.SerializeObject(metadata);
+            string stringifyMetadata = JsonConvert.SerializeObject(metadata, settings);
             string metadataBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(stringifyMetadata));
 
             context.Response.ContentType = "application/json";
@@ -127,7 +129,7 @@ namespace PactNet.AspNetCore.Messaging
         private static async Task WriteErrorInResponseAsync(HttpContext context, string errorMessage, HttpStatusCode statusCodeError)
         {
             context.Response.StatusCode = (int)statusCodeError;
-            await WriteToResponseAsync(context, errorMessage);
+            await context.Response.WriteAsync(errorMessage);
         }
     }
 }

--- a/src/PactNet.AspNetCore/Messaging/MessagingVerifierOptions.cs
+++ b/src/PactNet.AspNetCore/Messaging/MessagingVerifierOptions.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace PactNet.AspNetCore.Messaging
 {
     /// <summary>
@@ -9,5 +11,10 @@ namespace PactNet.AspNetCore.Messaging
         /// The base path of the message route
         /// </summary>
         public string BasePath { get; set; }
+
+        /// <summary>
+        /// Options for JSOn serialisation
+        /// </summary>
+        public JsonSerializerSettings DefaultJsonSettings { get; set; }
     }
 }


### PR DESCRIPTION
The existing pact that's checked in used UpperCamelCase on one side and lowerCamelCase on the other side. This is because on end allows setting JSOn options whereas the other doesn't. This change fixes that.