### PR TITLE
feat!: Configurable log level during consumer tests

### DIFF
--- a/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -25,7 +25,6 @@ namespace Consumer.Tests
         {
             var config = new PactConfig
             {
-                LogDir = "../../../logs/",
                 PactDir = "../../../pacts/",
                 Outputters = new[]
                 {

--- a/samples/EventImporter/Consumer.Tests/EventImporterTests.cs
+++ b/samples/EventImporter/Consumer.Tests/EventImporterTests.cs
@@ -17,7 +17,6 @@ namespace Consumer.Tests
 
         private readonly PactConfig config = new PactConfig
         {
-            LogDir = "../../../logs/",
             PactDir = "../../../pacts/",
             DefaultJsonSettings = new JsonSerializerSettings
             {

--- a/samples/ReadMe/Consumer.Tests/SomethingApiConsumerTests.cs
+++ b/samples/ReadMe/Consumer.Tests/SomethingApiConsumerTests.cs
@@ -21,8 +21,7 @@ namespace ReadMe.Consumer.Tests
             // or specify custom log and pact directories
             pact = Pact.V3("Something API Consumer", "Something API", new PactConfig
             {
-                PactDir = $"{Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.FullName}{Path.DirectorySeparatorChar}pacts",
-                LogDir = @"c:\temp\logs",
+                PactDir = $"{Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.FullName}{Path.DirectorySeparatorChar}pacts"
             });
 
             // Initialize Rust backend

--- a/src/PactNet.Abstractions/Constants.cs
+++ b/src/PactNet.Abstractions/Constants.cs
@@ -1,23 +1,16 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace PactNet
 {
     internal static class Constants
     {
-        public const string AdministrativeRequestHeaderKey = "X-Pact-Mock-Service";
-        public const string InteractionsPath = "/interactions";
-        public const string InteractionsVerificationPath = "/interactions/verification";
-        public const string PactPath = "/pact";
-
 #if USE_NET4X
         public static string BuildDirectory = new Uri(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase.Replace("file:///", ""))).LocalPath;
         public static string DefaultPactDir = Path.GetFullPath($"{BuildDirectory}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}pacts{Path.DirectorySeparatorChar}");
-        public static string DefaultLogDir = Path.GetFullPath($"{BuildDirectory}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}logs{Path.DirectorySeparatorChar}");
 #else
         public static string BuildDirectory = AppContext.BaseDirectory;
         public static string DefaultPactDir = Path.GetFullPath($"{BuildDirectory}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}pacts{Path.DirectorySeparatorChar}");
-        public static string DefaultLogDir = Path.GetFullPath($"{BuildDirectory}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}logs{Path.DirectorySeparatorChar}");
 #endif
     }
 }

--- a/src/PactNet.Abstractions/PactConfig.cs
+++ b/src/PactNet.Abstractions/PactConfig.cs
@@ -11,7 +11,6 @@ namespace PactNet
     public class PactConfig
     {
         private string _pactDir;
-        private string _logDir;
 
         /// <summary>
         /// Pact file destination directory
@@ -23,13 +22,9 @@ namespace PactNet
         }
 
         /// <summary>
-        /// Log file destination directory
+        /// Log level for the verifier
         /// </summary>
-        public string LogDir
-        {
-            get { return _logDir; }
-            set { _logDir = ConvertToDirectory(value); }
-        }
+        public PactLogLevel LogLevel { get; set; } = PactLogLevel.Information;
 
         /// <summary>
         /// Log outputs
@@ -50,7 +45,6 @@ namespace PactNet
         public PactConfig()
         {
             this.PactDir = Constants.DefaultPactDir;
-            this.LogDir = Constants.DefaultLogDir;
         }
 
         /// <summary>

--- a/src/PactNet/Interop/NativeInterop.cs
+++ b/src/PactNet/Interop/NativeInterop.cs
@@ -10,15 +10,6 @@ namespace PactNet.Interop
     {
         private const string dllName = "pact_ffi";
 
-        /// <summary>
-        /// Static initialiser for the Pact FFI library
-        /// </summary>
-        static NativeInterop()
-        {
-            // TODO: Make this configurable and specified by the user
-            LogToBuffer(LevelFilter.Debug);
-        }
-
         #region Http Interop Support
 
         [DllImport(dllName, EntryPoint = "pactffi_log_to_buffer")]

--- a/tests/PactNet.Abstractions.Tests/PactConfigTests.cs
+++ b/tests/PactNet.Abstractions.Tests/PactConfigTests.cs
@@ -12,13 +12,5 @@ namespace PactNet.Abstractions.Tests
 
             options.PactDir.Should().Be(Constants.DefaultPactDir);
         }
-
-        [Fact]
-        public void Ctor_WithDefaults_UsesDefaultLogDir()
-        {
-            var options = new PactConfig();
-
-            options.LogDir.Should().Be(Constants.DefaultLogDir);
-        }
     }
 }


### PR DESCRIPTION
Remove the hard-coded log level and allow it to be specified during mock server setup