### PR TITLE
chore!: Upgrade to .net 6 and drop explicit .Net Framework support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x" # runners already have .Net Framework installed as well
+          dotnet-version: "6.0.x" # runners already have .Net Framework installed as well
 
       - name: Pull interop dependencies
         run: bash -c "build/download-native-libs.sh"
@@ -52,14 +52,14 @@ jobs:
   release:
     needs: build-dotnet
     if: github.ref_type == 'tag'
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x" # runners already have .Net Framework installed as well
+          dotnet-version: "6.0.x" # runners already have .Net Framework installed as well
 
       - name: Pull interop dependencies
         run: bash -c "build/download-native-libs.sh"

--- a/samples/EventApi/Consumer.Tests/Consumer.Tests.csproj
+++ b/samples/EventApi/Consumer.Tests/Consumer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/EventApi/Consumer/Consumer.csproj
+++ b/samples/EventApi/Consumer/Consumer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/EventApi/Provider.Tests/Provider.Tests.csproj
+++ b/samples/EventApi/Provider.Tests/Provider.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/EventApi/Provider/Provider.csproj
+++ b/samples/EventApi/Provider/Provider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/EventImporter/Consumer.Tests/Consumer.Tests.csproj
+++ b/samples/EventImporter/Consumer.Tests/Consumer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/EventImporter/Consumer/Consumer.csproj
+++ b/samples/EventImporter/Consumer/Consumer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/EventImporter/Provider.Tests/Provider.Tests.csproj
+++ b/samples/EventImporter/Provider.Tests/Provider.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/EventImporter/Provider/Provider.csproj
+++ b/samples/EventImporter/Provider/Provider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/ReadMe/Consumer.Tests/Readme.Consumer.Tests.csproj
+++ b/samples/ReadMe/Consumer.Tests/Readme.Consumer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/ReadMe/Consumer/Readme.Consumer.csproj
+++ b/samples/ReadMe/Consumer/Readme.Consumer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/ReadMe/Provider.Tests/Readme.Provider.Tests.csproj
+++ b/samples/ReadMe/Provider.Tests/Readme.Provider.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/ReadMe/Provider/Readme.Provider.csproj
+++ b/samples/ReadMe/Provider/Readme.Provider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/PactNet.Abstractions/PactNet.Abstractions.csproj
+++ b/src/PactNet.Abstractions/PactNet.Abstractions.csproj
@@ -1,11 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
-      netstandard2.0
-    </TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      netstandard2.0; net46
-    </TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591;NU5105</NoWarn>

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -1,12 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
-      netstandard2.0
-    </TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      netstandard2.0; net46
-    </TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>NU5105</NoWarn>

--- a/tests/PactNet.Abstractions.Tests/PactNet.Abstractions.Tests.csproj
+++ b/tests/PactNet.Abstractions.Tests/PactNet.Abstractions.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
-      net50
+      net6.0
     </TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      net50;net46
+      net6.0;net461
     </TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/tests/PactNet.Tests/PactNet.Tests.csproj
+++ b/tests/PactNet.Tests/PactNet.Tests.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
-      net50
+      net6.0
     </TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      net50;net46
+      net6.0;net461
     </TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
.Net Framework 4.6.1 and above support .Net Standard 2.0 so there's no real need to ship explicit .Net Framework support. We still run the tests on .Net Framework just to be sure that we've tested compatibility though.

This has the added bonus that the release CI can run on Ubuntu instead of Windows which means it's much much faster.