### PR TITLE
fix!: Prevent invalid message interactions via type state pattern

### DIFF
--- a/samples/Messaging/Consumer.Tests/StockEventProcessorTests.cs
+++ b/samples/Messaging/Consumer.Tests/StockEventProcessorTests.cs
@@ -33,31 +33,30 @@ namespace Consumer.Tests
         }
 
         [Fact]
-        public void RecieveSomeStockEvents()
+        public void ReceiveSomeStockEvents()
         {
             this.messagePact
                 .ExpectsToReceive("some stock ticker events")
                 .Given("A list of events is pushed to the queue")
                 .WithMetadata("key", "valueKey")
                 .WithJsonContent(Match.MinType(new
-                 {
-                     Name = Match.Type("AAPL"),
-                     Price = Match.Decimal(1.23m),
-                     Timestamp = Match.Type(14.February(2022).At(13, 14, 15, 678))
-                 }, 1));
-
-            this.messagePact.Verify<ICollection<StockEvent>>(events =>
-            {
-                events.Should().BeEquivalentTo(new[]
                 {
-                    new StockEvent
+                    Name = Match.Type("AAPL"),
+                    Price = Match.Decimal(1.23m),
+                    Timestamp = Match.Type(14.February(2022).At(13, 14, 15, 678))
+                }, 1))
+                .Verify<ICollection<StockEvent>>(events =>
+                {
+                    events.Should().BeEquivalentTo(new[]
                     {
-                        Name = "AAPL",
-                        Price = 1.23m,
-                        Timestamp = 14.February(2022).At(13, 14, 15, 678)
-                    }
+                        new StockEvent
+                        {
+                            Name = "AAPL",
+                            Price = 1.23m,
+                            Timestamp = 14.February(2022).At(13, 14, 15, 678)
+                        }
+                    });
                 });
-            });
         }
     }
 }

--- a/src/PactNet.Abstractions/IConfiguredMessageVerifier.cs
+++ b/src/PactNet.Abstractions/IConfiguredMessageVerifier.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+namespace PactNet
+{
+    /// <summary>
+    /// A configured message type state, which can now be verified
+    /// </summary>
+    public interface IConfiguredMessageVerifier
+    {
+        /// <summary>
+        /// Verify a message is read and handled correctly
+        /// </summary>
+        /// <param name="handler">The method using the message</param>
+        void Verify<T>(Action<T> handler);
+
+        /// <summary>
+        /// Verify a message is read and handled correctly
+        /// </summary>
+        /// <param name="handler">The method using the message</param>
+        Task VerifyAsync<T>(Func<T, Task> handler);
+    }
+}

--- a/src/PactNet.Abstractions/IMessageBuilder.cs
+++ b/src/PactNet.Abstractions/IMessageBuilder.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace PactNet
 {
     /// <summary>
-    /// Build up a mock message for a v3 message messagePact
+    /// Build up a mock message for a v3 message message pact
     /// </summary>
     public interface IMessageBuilderV3
     {
@@ -35,15 +35,15 @@ namespace PactNet
         /// Set message content which is serialised as JSON
         /// </summary>
         /// <param name="body">Message body</param>
-        /// <returns>Fluent builder</returns>
-        IMessageBuilderV3 WithJsonContent(dynamic body);
+        /// <returns>Configured message</returns>
+        IConfiguredMessageVerifier WithJsonContent(dynamic body);
 
         /// <summary>
         /// Set message content which is serialised as JSON
         /// </summary>
         /// <param name="body">Message body</param>
         /// <param name="settings">Custom JSON serializer settings</param>
-        /// <returns>Fluent builder</returns>
-        IMessageBuilderV3 WithJsonContent(dynamic body, JsonSerializerSettings settings);
+        /// <returns>Configured message</returns>
+        IConfiguredMessageVerifier WithJsonContent(dynamic body, JsonSerializerSettings settings);
     }
 }

--- a/src/PactNet.Abstractions/IMessagePactBuilder.cs
+++ b/src/PactNet.Abstractions/IMessagePactBuilder.cs
@@ -1,30 +1,9 @@
-using System;
-using System.Threading.Tasks;
-
 namespace PactNet
 {
     /// <summary>
-    /// Message pact Builder
-    /// </summary>
-    public interface IMessagePactBuilder
-    {
-        /// <summary>
-        /// Verify a message is read and handled correctly
-        /// </summary>
-        /// <param name="handler">The method using the message</param>
-        void Verify<T>(Action<T> handler);
-
-        /// <summary>
-        /// Verify a message is read and handled correctly
-        /// </summary>
-        /// <param name="handler">The method using the message</param>
-        Task VerifyAsync<T>(Func<T, Task> handler);
-    }
-
-    /// <summary>
     /// Message pact v3 Builder
     /// </summary>
-    public interface IMessagePactBuilderV3 : IMessagePactBuilder
+    public interface IMessagePactBuilderV3
     {
         /// <summary>
         /// Add a new message to the pact

--- a/src/PactNet/ConfiguredMessageVerifier.cs
+++ b/src/PactNet/ConfiguredMessageVerifier.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using PactNet.Exceptions;
+using PactNet.Interop;
+using PactNet.Models;
+
+namespace PactNet
+{
+    /// <summary>
+    /// Verifies a configured message interaction
+    /// </summary>
+    public class ConfiguredMessageVerifier : IConfiguredMessageVerifier
+    {
+        private readonly MessageHandle message;
+        private readonly IMessageMockServer server;
+        private readonly MessagePactHandle pact;
+        private readonly PactConfig config;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="ConfiguredMessageVerifier"/>
+        /// </summary>
+        /// <param name="server">Message server</param>
+        /// <param name="pact">Pact handle</param>
+        /// <param name="message">Message handle</param>
+        /// <param name="config">Pact configuration</param>
+        internal ConfiguredMessageVerifier(IMessageMockServer server, MessagePactHandle pact, MessageHandle message, PactConfig config)
+        {
+            this.server = server;
+            this.pact = pact;
+            this.message = message;
+            this.config = config;
+        }
+
+        /// <summary>
+        /// Verify a message is read and handled correctly and write the message pact
+        /// </summary>
+        /// <param name="handler">The method using the message</param>
+        public void Verify<T>(Action<T> handler)
+        {
+            try
+            {
+                var messageReified = this.MessageReified<T>();
+
+                handler(messageReified);
+
+                this.WritePact();
+            }
+            catch (Exception e)
+            {
+                throw new PactMessageConsumerVerificationException($"The message {this.message} could not be verified by the consumer handler", e);
+            }
+        }
+
+        /// <summary>
+        /// Verify a message is read and handled correctly and write the message pact
+        /// </summary>
+        /// <param name="handler">The method using the message</param>
+        public async Task VerifyAsync<T>(Func<T, Task> handler)
+        {
+            try
+            {
+                var messageReified = this.MessageReified<T>();
+
+                await handler(messageReified);
+
+                this.WritePact();
+            }
+            catch (Exception e)
+            {
+                throw new PactMessageConsumerVerificationException($"The message {this.message} could not be verified by the consumer handler", e);
+            }
+        }
+
+        /// <summary>
+        /// Try to read the reified message
+        /// </summary>
+        /// <typeparam name="T">the type of message</typeparam>
+        /// <returns>the message</returns>
+        private T MessageReified<T>()
+        {
+            string reified = this.server.Reify(this.message);
+            NativeMessage content = JsonConvert.DeserializeObject<NativeMessage>(reified);
+
+            T messageReified = JsonConvert.DeserializeObject<T>(content.Contents.ToString());
+            return messageReified;
+        }
+
+        /// <summary>
+        /// Write the pact file
+        /// </summary>
+        private void WritePact()
+        {
+            this.server.WriteMessagePactFile(this.pact, this.config.PactDir, false);
+        }
+    }
+}

--- a/src/PactNet/MockServer.cs
+++ b/src/PactNet/MockServer.cs
@@ -136,6 +136,7 @@ namespace PactNet
             var allocatedString = Marshal.PtrToStringAnsi(NativeInterop.MessageReify(message));
             return allocatedString;
         }
+
         public void WriteMessagePactFile(MessagePactHandle pact, string directory, bool overwrite)
         {
             var result = NativeInterop.WriteMessagePactFile(pact, directory, overwrite);

--- a/tests/PactNet.Tests/MessageBuilderTests.cs
+++ b/tests/PactNet.Tests/MessageBuilderTests.cs
@@ -15,20 +15,22 @@ namespace PactNet.Tests
 
         private readonly Mock<IMessageMockServer> mockedServer;
 
+        private readonly MessagePactHandle pact;
         private readonly MessageHandle handle;
-        private readonly JsonSerializerSettings settings;
+        private readonly PactConfig config;
 
         public MessageBuilderTests()
         {
             var fixture = new Fixture();
             var customization = new SupportMutableValueTypesCustomization();
             customization.Customize(fixture);
-            
+
+            this.pact = fixture.Create<MessagePactHandle>();
             this.handle = fixture.Create<MessageHandle>();
             this.mockedServer = new Mock<IMessageMockServer>();
-            this.settings = new JsonSerializerSettings();
+            this.config = new PactConfig { DefaultJsonSettings = new JsonSerializerSettings() };
 
-            this.builder = new MessageBuilder(this.mockedServer.Object, this.handle, this.settings);
+            this.builder = new MessageBuilder(this.mockedServer.Object, this.pact, this.handle, this.config);
         }
 
         [Fact]

--- a/tests/PactNet.Tests/PactExtensionsTests.cs
+++ b/tests/PactNet.Tests/PactExtensionsTests.cs
@@ -153,9 +153,8 @@ namespace PactNet.Tests
                     ["baz"] = "bash"
                 })
                 .WithMetadata("queueId", "1234")
-                .WithJsonContent(new TestData { Int = 1, String = "a description" });
-
-            builder.Verify<TestData>(_ => { });
+                .WithJsonContent(new TestData { Int = 1, String = "a description" })
+                .Verify<TestData>(_ => { });
 
             string actualPact = File.ReadAllText("PactExtensionsTests-MessageConsumer-V3-PactExtensionsTests-MessageProvider.json").TrimEnd();
             string expectedPact = File.ReadAllText("data/v3-message-consumer-integration.json").TrimEnd();

--- a/tests/PactNet.Tests/PactMessageBuilderTests.cs
+++ b/tests/PactNet.Tests/PactMessageBuilderTests.cs
@@ -74,14 +74,14 @@ namespace PactNet.Tests
         {
             //Arrange
             var content = new MessageModel { Id = 1, Description = "description" };
-            this.messagePact
-                .ExpectsToReceive("a description")
-                .WithJsonContent(content);
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(content);
 
             SetServerReifyMessage(JsonConvert.SerializeObject(content.ToNativeMessage()));
 
             //Act
-            this.messagePact.Verify<MessageModel>(_ => { });
+            message.Verify<MessageModel>(_ => { });
 
             this.mockedServer.Verify(s => s.WriteMessagePactFile(It.IsAny<MessagePactHandle>(), It.IsAny<string>(), false));
         }
@@ -90,12 +90,16 @@ namespace PactNet.Tests
         public void Verify_Should_Fail_If_Type_Is_Not_The_Same_As_The_Message()
         {
             //Arrange
+            var content = new MessageModel { Id = 1, Description = "description" };
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(content);
+
             SetServerReifyMessage("{ \"param1\": \"value1\" }");
 
             //Act
-            this.messagePact
-                .Invoking(x => x.Verify<MessageModel>(_ => { }))
-                .Should().Throw<PactMessageConsumerVerificationException>();
+            message.Invoking(x => x.Verify<MessageModel>(_ => { }))
+                   .Should().Throw<PactMessageConsumerVerificationException>();
         }
 
         [Fact]
@@ -103,13 +107,15 @@ namespace PactNet.Tests
         {
             //Arrange
             var testMessage = new MessageModel(1, string.Empty).ToNativeMessage();
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(testMessage);
 
             SetServerReifyMessage(JsonConvert.SerializeObject(testMessage));
 
             //Act
-            this.messagePact
-                .Invoking(x => x.Verify<MessageModel>(_ => throw new Exception("an exception when running the consumer handler")))
-                .Should().Throw<PactMessageConsumerVerificationException>();
+            message.Invoking(x => x.Verify<MessageModel>(_ => throw new Exception("an exception when running the consumer handler")))
+                   .Should().Throw<PactMessageConsumerVerificationException>();
         }
 
         [Fact]
@@ -117,14 +123,14 @@ namespace PactNet.Tests
         {
             //Arrange
             var content = new MessageModel { Id = 1, Description = "description" };
-            this.messagePact
-                .ExpectsToReceive("a description")
-                .WithJsonContent(content);
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(content);
 
             SetServerReifyMessage(JsonConvert.SerializeObject(content.ToNativeMessage()));
 
             //Act
-            await this.messagePact.VerifyAsync<MessageModel>(_ => Task.CompletedTask);
+            await message.VerifyAsync<MessageModel>(_ => Task.CompletedTask);
 
             this.mockedServer.Verify(s => s.WriteMessagePactFile(It.IsAny<MessagePactHandle>(), It.IsAny<string>(), false));
         }
@@ -133,9 +139,14 @@ namespace PactNet.Tests
         public async Task VerifyAsync_Should_Fail_If_Type_Is_Not_The_Same_As_The_Message()
         {
             //Arrange
+            var content = new MessageModel { Id = 1, Description = "description" };
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(content);
+
             SetServerReifyMessage("{ \"param1\": \"value1\" }");
 
-            Func<Task> actual = this.messagePact.Awaiting(x => x.VerifyAsync<MessageModel>(_ => Task.CompletedTask));
+            Func<Task> actual = message.Awaiting(x => x.VerifyAsync<MessageModel>(_ => Task.CompletedTask));
 
             await actual.Should().ThrowAsync<PactMessageConsumerVerificationException>();
         }
@@ -145,10 +156,13 @@ namespace PactNet.Tests
         {
             //Arrange
             var testMessage = new MessageModel(1, string.Empty).ToNativeMessage();
+            var message = this.messagePact
+                              .ExpectsToReceive("a description")
+                              .WithJsonContent(testMessage);
 
             SetServerReifyMessage(JsonConvert.SerializeObject(testMessage));
 
-            Func<Task> actual = this.messagePact.Awaiting(x => x.VerifyAsync<MessageModel>(_ => throw new Exception("an exception when running the consumer handler")));
+            Func<Task> actual = () => message.VerifyAsync<MessageModel>(_ => throw new Exception("an exception when running the consumer handler"));
 
             await actual.Should().ThrowAsync<PactMessageConsumerVerificationException>();
         }


### PR DESCRIPTION
The previous API allowed you to:

- run verification without ever configuring any interactions
- configure multiple interactions, but then the verification only
  applied to the last one
- configure the message in invalid ways, such as by specifying the
  content multiple times or not at all

The new API adds the Verify call onto the message itself, and is
available only once the content has been configured. This ensures the
content is configured exactly once and that all messages must be
verified.

You can still specify provider states and metadata multiple times, but

1. That's valid
2. They must be before the content is defined, which is only allowed
   once