### PR TITLE
feat: Injecting values from provider state callbacks

### DIFF
--- a/src/PactNet.Abstractions/Generators/Generate.cs
+++ b/src/PactNet.Abstractions/Generators/Generate.cs
@@ -1,0 +1,15 @@
+namespace PactNet.Generators;
+
+public static class Generate
+{
+    /// <summary>
+    /// Generates a value that is looked up from the provider state context using the given expression
+    /// </summary>
+    /// <param name="example">Example value</param>
+    /// <param name="expression">String expression</param>
+    /// <returns>Generator</returns>
+    public static IGenerator ProviderState(string example, string expression)
+    {
+        return new ProviderStateGenerator(example, expression);
+    }
+}

--- a/src/PactNet.Abstractions/Generators/IGenerator.cs
+++ b/src/PactNet.Abstractions/Generators/IGenerator.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+using PactNet.Matchers;
+
+namespace PactNet.Generators;
+
+public interface IGenerator : IMatcher
+{
+    /// <summary>
+    /// Type of the generator
+    /// </summary>
+    [JsonProperty("pact:generator:type")]
+    string GeneratorType { get; }
+}

--- a/src/PactNet.Abstractions/Generators/ProviderStateGenerator.cs
+++ b/src/PactNet.Abstractions/Generators/ProviderStateGenerator.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using PactNet.Matchers;
+
+namespace PactNet.Generators;
+
+public class ProviderStateGenerator : IGenerator
+{
+    public string Type => "type";
+
+    public dynamic Value { get; }
+
+    public string GeneratorType => "ProviderState";
+
+    /// <summary>
+    /// Expression to lookup in provider state context
+    /// </summary>
+    [JsonProperty("expression")]
+    public string Expression { get; }
+
+    public ProviderStateGenerator(dynamic example, string expression)
+    {
+        this.Value = example;
+        this.Expression = expression;
+    }
+}

--- a/src/PactNet.Abstractions/IRequestBuilder.cs
+++ b/src/PactNet.Abstractions/IRequestBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using Newtonsoft.Json;
+using PactNet.Generators;
 using PactNet.Matchers;
 
 namespace PactNet
@@ -117,6 +118,22 @@ namespace PactNet
         IRequestBuilderV3 WithRequest(string method, string path);
 
         /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 WithRequest(HttpMethod method, IGenerator generator);
+
+        /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 WithRequest(string method, IGenerator generator);
+
+        /// <summary>
         /// Add a query string parameter
         /// </summary>
         /// <param name="key">Query parameter key</param>
@@ -124,6 +141,15 @@ namespace PactNet
         /// <returns>Fluent builder</returns>
         /// <remarks>You can add a query parameter with the same key multiple times</remarks>
         IRequestBuilderV3 WithQuery(string key, string value);
+
+        /// <summary>
+        /// Add a query string parameter
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="generator">Query parameter value generator</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        IRequestBuilderV3 WithQuery(string key, IGenerator generator);
 
         /// <summary>
         /// Add a request header

--- a/src/PactNet/RequestBuilder.cs
+++ b/src/PactNet/RequestBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Newtonsoft.Json;
+using PactNet.Generators;
 using PactNet.Interop;
 using PactNet.Matchers;
 
@@ -149,10 +150,28 @@ namespace PactNet
         /// Set the request
         /// </summary>
         /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 IRequestBuilderV3.WithRequest(HttpMethod method, IGenerator generator)
+            => this.WithRequest(method, generator);
+
+        /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
         /// <param name="path">Request path</param>
         /// <returns>Fluent builder</returns>
         IRequestBuilderV3 IRequestBuilderV3.WithRequest(string method, string path)
             => this.WithRequest(method, path);
+
+        /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 IRequestBuilderV3.WithRequest(string method, IGenerator generator)
+            => this.WithRequest(method, generator);
 
         /// <summary>
         /// Add a query string parameter
@@ -163,6 +182,16 @@ namespace PactNet
         /// <remarks>You can add a query parameter with the same key multiple times</remarks>
         IRequestBuilderV3 IRequestBuilderV3.WithQuery(string key, string value)
             => this.WithQuery(key, value);
+
+        /// <summary>
+        /// Add a query string parameter
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="generator">Query parameter value generator</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        IRequestBuilderV3 IRequestBuilderV3.WithQuery(string key, IGenerator generator)
+            => this.WithQuery(key, generator);
 
         /// <summary>
         /// Add a request header
@@ -248,6 +277,15 @@ namespace PactNet
         /// Set the request
         /// </summary>
         /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        internal RequestBuilder WithRequest(HttpMethod method, IGenerator generator)
+            => this.WithRequest(method.Method, generator);
+
+        /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
         /// <param name="path">Request path</param>
         /// <returns>Fluent builder</returns>
         internal RequestBuilder WithRequest(string method, string path)
@@ -256,6 +294,18 @@ namespace PactNet
 
             this.server.WithRequest(this.interaction, method, path);
             return this;
+        }
+
+        /// <summary>
+        /// Set the request
+        /// </summary>
+        /// <param name="method">Request method</param>
+        /// <param name="generator">Path value generator</param>
+        /// <returns>Fluent builder</returns>
+        internal RequestBuilder WithRequest(string method, IGenerator generator)
+        {
+            var serialised = JsonConvert.SerializeObject(generator, this.defaultSettings);
+            return this.WithRequest(method, serialised);
         }
 
         /// <summary>
@@ -273,6 +323,20 @@ namespace PactNet
             this.server.WithQueryParameter(this.interaction, key, value, index);
             return this;
         }
+
+        /// <summary>
+        /// Add a query string parameter
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="generator">Query parameter value generator</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        internal RequestBuilder WithQuery(string key, IGenerator generator)
+        {
+            var serialised = JsonConvert.SerializeObject(generator, this.defaultSettings);
+            return this.WithQuery(key, serialised);
+        }
+
 
         /// <summary>
         /// Add a request header

--- a/tests/PactNet.Abstractions.Tests/Generators/GenerateTests.cs
+++ b/tests/PactNet.Abstractions.Tests/Generators/GenerateTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using PactNet.Generators;
+using Xunit;
+
+namespace PactNet.Abstractions.Tests.Generators
+{
+    public class GenerateTests
+    {
+        [Fact]
+        public void ProviderState_WhenCalled_ReturnsGenerator()
+        {
+            const string example = "/ticket/WO1FN";
+            const string expression = @"/ticket/${pnr}";
+
+            var matcher = Generate.ProviderState(example, expression);
+
+            matcher.Should().BeEquivalentTo(new ProviderStateGenerator(example, expression));
+        }
+    }
+}

--- a/tests/PactNet.Abstractions.Tests/Generators/ProviderStateGeneratorTests.cs
+++ b/tests/PactNet.Abstractions.Tests/Generators/ProviderStateGeneratorTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using PactNet.Generators;
+using PactNet.Matchers;
+using Xunit;
+
+namespace PactNet.Abstractions.Tests.Generators
+{
+    public class ProviderStateGeneratorTests
+    {
+        [Fact]
+        public void Ctor_WhenCalled_SerialisesCorrectly()
+        {
+            const string example = "hello@tester.com";
+            const string expression = "${email}";
+
+            var generator = new ProviderStateGenerator(example, expression);
+
+            string actual = JsonConvert.SerializeObject(generator);
+            string expected = $@"{{""pact:matcher:type"":""type"",""value"":""{example}"",""pact:generator:type"":""ProviderState"",""expression"":""{expression}""}}";
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
Enable generator type provider state.

Now rust is support provider state injection I have proved it on my client project.
I'll write some usage sample probably inside existing EventAPI.