### PR TITLE
feat: Allow publishing verification results for URI sources (#392)

### DIFF
--- a/src/PactNet.Abstractions/Verifier/IPactBrokerOptions.cs
+++ b/src/PactNet.Abstractions/Verifier/IPactBrokerOptions.cs
@@ -74,7 +74,14 @@ namespace PactNet.Verifier
         IPactBrokerOptions IncludeWipPactsSince(DateTime date);
 
         /// <summary>
-        /// Publish results to the pact broker
+        /// Publish results to the pact broker without any additional settings
+        /// </summary>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        IPactBrokerOptions PublishResults(string providerVersion);
+
+        /// <summary>
+        /// Publish results to the pact broker with additional settings such as provider branch
         /// </summary>
         /// <param name="providerVersion">Provider version</param>
         /// <param name="configure">Configure the publish options</param>
@@ -82,7 +89,15 @@ namespace PactNet.Verifier
         IPactBrokerOptions PublishResults(string providerVersion, Action<IPactBrokerPublishOptions> configure);
 
         /// <summary>
-        /// Publish results to the pact broker if the condition is met
+        /// Publish results to the pact broker without any additional settings, if the condition is met
+        /// </summary>
+        /// <param name="condition">Only publish if this condition is true</param>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        IPactBrokerOptions PublishResults(bool condition, string providerVersion);
+
+        /// <summary>
+        /// Publish results to the pact broker with additional settings such as provider branch, if the condition is met
         /// </summary>
         /// <param name="condition">Only publish if this condition is true</param>
         /// <param name="providerVersion">Provider version</param>

--- a/src/PactNet.Abstractions/Verifier/IPactUriOptions.cs
+++ b/src/PactNet.Abstractions/Verifier/IPactUriOptions.cs
@@ -23,7 +23,14 @@ namespace PactNet.Verifier
         IPactUriOptions TokenAuthentication(string token);
 
         /// <summary>
-        /// Publish results to the pact broker
+        /// Publish results to the pact broker without any additional settings
+        /// </summary>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        IPactUriOptions PublishResults(string providerVersion);
+
+        /// <summary>
+        /// Publish results to the pact broker with additional settings such as provider branch
         /// </summary>
         /// <param name="providerVersion">Provider version</param>
         /// <param name="configure">Configure the publish options</param>
@@ -31,7 +38,15 @@ namespace PactNet.Verifier
         IPactUriOptions PublishResults(string providerVersion, Action<IPactBrokerPublishOptions> configure);
 
         /// <summary>
-        /// Publish results to the pact broker if the condition is met
+        /// Publish results to the pact broker without any additional settings, if the condition is met
+        /// </summary>
+        /// <param name="condition">Only publish if this condition is true</param>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        IPactUriOptions PublishResults(bool condition, string providerVersion);
+
+        /// <summary>
+        /// Publish results to the pact broker with additional settings such as provider branch, if the condition is met
         /// </summary>
         /// <param name="condition">Only publish if this condition is true</param>
         /// <param name="providerVersion">Provider version</param>

--- a/src/PactNet/Verifier/PactBrokerOptions.cs
+++ b/src/PactNet/Verifier/PactBrokerOptions.cs
@@ -156,6 +156,14 @@ namespace PactNet.Verifier
         }
 
         /// <summary>
+        /// Publish results to the pact broker without any additional settings
+        /// </summary>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        public IPactBrokerOptions PublishResults(string providerVersion)
+            => this.PublishResults(providerVersion, _ => { });
+
+        /// <summary>
         /// Publish results to the pact broker
         /// </summary>
         /// <param name="providerVersion">Provider version</param>
@@ -172,6 +180,15 @@ namespace PactNet.Verifier
 
             return this;
         }
+
+        /// <summary>
+        /// Publish results to the pact broker without any additional settings, if the condition is met
+        /// </summary>
+        /// <param name="condition">Only publish if this condition is true</param>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        public IPactBrokerOptions PublishResults(bool condition, string providerVersion)
+            => this.PublishResults(condition, providerVersion, _ => { });
 
         /// <summary>
         /// Publish results to the pact broker if the condition is met

--- a/src/PactNet/Verifier/PactUriOptions.cs
+++ b/src/PactNet/Verifier/PactUriOptions.cs
@@ -58,6 +58,14 @@ namespace PactNet.Verifier
         }
 
         /// <summary>
+        /// Publish results to the pact broker without any additional settings
+        /// </summary>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        public IPactUriOptions PublishResults(string providerVersion)
+            => this.PublishResults(providerVersion, _ => { });
+
+        /// <summary>
         /// Publish results to the pact broker
         /// </summary>
         /// <param name="providerVersion">Provider version</param>
@@ -74,6 +82,15 @@ namespace PactNet.Verifier
 
             return this;
         }
+
+        /// <summary>
+        /// Publish results to the pact broker without any additional settings, if the condition is met
+        /// </summary>
+        /// <param name="condition">Only publish if this condition is true</param>
+        /// <param name="providerVersion">Provider version</param>
+        /// <returns>Fluent builder</returns>
+        public IPactUriOptions PublishResults(bool condition, string providerVersion)
+            => this.PublishResults(condition, providerVersion, _ => { });
 
         /// <summary>
         /// Publish results to the pact broker if the condition is met

--- a/tests/PactNet.Tests/Verifier/PactBrokerOptionsTests.cs
+++ b/tests/PactNet.Tests/Verifier/PactBrokerOptionsTests.cs
@@ -118,7 +118,7 @@ namespace PactNet.Tests.Verifier
         }
 
         [Fact]
-        public void FromPactBroker_IncludeWipSince_AddsPactBrokerPendingArgs()
+        public void IncludeWipPactsSince_WhenCalled_AddsPactBrokerPendingArgs()
         {
             this.options.IncludeWipPactsSince(14.February(2021));
 
@@ -126,34 +126,49 @@ namespace PactNet.Tests.Verifier
         }
 
         [Fact]
-        public void PublishResults_WhenCalled_AddsPublishArgs()
+        public void PublishResults_WithoutExtraSettings_AddsPublishArgs()
         {
-            this.options.PublishResults("1.2.3", _ => { });
-            this.options.Apply();
+            this.options.PublishResults("1.2.3");
 
-            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3",
-                                                              It.IsAny<Uri>(),
-                                                              It.IsAny<ICollection<string>>(),
-                                                              It.IsAny<string>()));
+            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3", null, Array.Empty<string>(), null));
+        }
+
+        [Fact]
+        public void PublishResults_WithExtraSettings_AddsPublishArgs()
+        {
+            var buildUri = new Uri("https://ci.example.org/build/1");
+
+            this.options.PublishResults("1.2.3", settings => settings.ProviderBranch("branch")
+                                                                     .ProviderTags("tag1", "tag2")
+                                                                     .BuildUri(buildUri));
+
+            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3", buildUri, new[] { "tag1", "tag2" }, "branch"));
         }
 
         [Fact]
         public void PublishResults_ConditionMet_AddsPublishArgs()
         {
-            this.options.PublishResults(true, "1.2.3", _ => { });
-            this.options.Apply();
+            this.options.PublishResults(true, "1.2.3");
 
-            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3",
-                                                              It.IsAny<Uri>(),
-                                                              It.IsAny<ICollection<string>>(),
-                                                              It.IsAny<string>()));
+            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3", null, Array.Empty<string>(), null));
+        }
+
+        [Fact]
+        public void PublishResults_ConditionMet_AddsAdditionalOptions()
+        {
+            var buildUri = new Uri("https://ci.example.org/build/1");
+
+            this.options.PublishResults(true, "1.2.3", settings => settings.ProviderBranch("branch")
+                                                                           .ProviderTags("tag1", "tag2")
+                                                                           .BuildUri(buildUri));
+
+            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3", buildUri, new[] { "tag1", "tag2" }, "branch"));
         }
 
         [Fact]
         public void PublishResults_ConditionNotMet_DoesNotAddPublishArgs()
         {
             this.options.PublishResults(false, null, null);
-            this.options.Apply();
 
             this.mockProvider.Verify(p => p.SetPublishOptions(It.IsAny<string>(),
                                                               It.IsAny<Uri>(),

--- a/tests/PactNet.Tests/Verifier/PactUriOptionsTests.cs
+++ b/tests/PactNet.Tests/Verifier/PactUriOptionsTests.cs
@@ -60,34 +60,55 @@ namespace PactNet.Tests.Verifier
         }
 
         [Fact]
-        public void PublishResults_WhenCalled_AddsPublishArgs()
+        public void PublishResults_WithoutExtraSettings_AddsPublishArgs()
         {
-            this.options.PublishResults("1.2.3", _ => { });
-            this.options.Apply();
+            this.mockProvider.Setup(p => p.SetPublishOptions("1.2.3", null, Array.Empty<string>(), null));
 
-            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3",
-                                                              It.IsAny<Uri>(),
-                                                              It.IsAny<ICollection<string>>(),
-                                                              It.IsAny<string>()));
+            this.options.PublishResults("1.2.3");
+
+            this.mockProvider.Verify();
+        }
+
+        [Fact]
+        public void PublishResults_WithExtraSettings_AddsPublishArgs()
+        {
+            var buildUri = new Uri("https://ci.example.org/build/1");
+            this.mockProvider.Setup(p => p.SetPublishOptions("1.2.3", buildUri, new[] { "tag1", "tag2" }, "branch"));
+
+            this.options.PublishResults("1.2.3", settings => settings.ProviderBranch("branch")
+                                                                     .ProviderTags("tag1", "tag2")
+                                                                     .BuildUri(buildUri));
+
+            this.mockProvider.Verify();
         }
 
         [Fact]
         public void PublishResults_ConditionMet_AddsPublishArgs()
         {
-            this.options.PublishResults(true, "1.2.3", _ => { });
-            this.options.Apply();
+            this.mockProvider.Setup(p => p.SetPublishOptions("1.2.3", null, Array.Empty<string>(), null));
 
-            this.mockProvider.Verify(p => p.SetPublishOptions("1.2.3",
-                                                              It.IsAny<Uri>(),
-                                                              It.IsAny<ICollection<string>>(),
-                                                              It.IsAny<string>()));
+            this.options.PublishResults(true, "1.2.3");
+
+            this.mockProvider.Verify();
+        }
+
+        [Fact]
+        public void PublishResults_ConditionMet_AddsAdditionalOptions()
+        {
+            var buildUri = new Uri("https://ci.example.org/build/1");
+            this.mockProvider.Setup(p => p.SetPublishOptions("1.2.3", buildUri, new[] { "tag1", "tag2" }, "branch"));
+
+            this.options.PublishResults(true, "1.2.3", settings => settings.ProviderBranch("branch")
+                                                                           .ProviderTags("tag1", "tag2")
+                                                                           .BuildUri(buildUri));
+
+            this.mockProvider.Verify();
         }
 
         [Fact]
         public void PublishResults_ConditionNotMet_DoesNotAddPublishArgs()
         {
             this.options.PublishResults(false, null, null);
-            this.options.Apply();
 
             this.mockProvider.Verify(p => p.SetPublishOptions(It.IsAny<string>(),
                                                               It.IsAny<Uri>(),


### PR DESCRIPTION
See the linked issue #392 for additional information

Draft currently as it's unclear where the broker URI is going to come from. Perhaps this is built into the FFI, but that doesn't seem safe to me.