### PR TITLE
feat: Support non-JSON request and response bodies (#391)

### DIFF
--- a/src/PactNet.Abstractions/IRequestBuilder.cs
+++ b/src/PactNet.Abstractions/IRequestBuilder.cs
@@ -91,6 +91,14 @@ namespace PactNet
         IRequestBuilderV2 WithJsonBody(dynamic body, JsonSerializerSettings settings, string contentType);
 
         /// <summary>
+        /// A pre-formatted body which should be used as-is for the request 
+        /// </summary>
+        /// <param name="body">Request body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV2 WithBody(string body, string contentType);
+
+        /// <summary>
         /// Define the response to this request
         /// </summary>
         /// <returns>Response builder</returns>
@@ -189,6 +197,14 @@ namespace PactNet
         /// <param name="contentType">Content type override</param>
         /// <returns>Fluent builder</returns>
         IRequestBuilderV3 WithJsonBody(dynamic body, JsonSerializerSettings settings, string contentType);
+
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the request 
+        /// </summary>
+        /// <param name="body">Request body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 WithBody(string body, string contentType);
 
         // TODO: Support binary and multi-part body
 

--- a/src/PactNet.Abstractions/IResponseBuilder.cs
+++ b/src/PactNet.Abstractions/IResponseBuilder.cs
@@ -53,6 +53,14 @@ namespace PactNet
         /// <param name="settings">Custom JSON serializer settings</param>
         /// <returns>Fluent builder</returns>
         IResponseBuilderV2 WithJsonBody(dynamic body, JsonSerializerSettings settings);
+
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the response 
+        /// </summary>
+        /// <param name="body">Response body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IResponseBuilderV2 WithBody(string body, string contentType);
     }
 
     /// <summary>
@@ -104,5 +112,13 @@ namespace PactNet
         /// <param name="settings">Custom JSON serializer settings</param>
         /// <returns>Fluent builder</returns>
         IResponseBuilderV3 WithJsonBody(dynamic body, JsonSerializerSettings settings);
+
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the response 
+        /// </summary>
+        /// <param name="body">Response body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IResponseBuilderV3 WithBody(string body, string contentType);
     }
 }

--- a/src/PactNet/RequestBuilder.cs
+++ b/src/PactNet/RequestBuilder.cs
@@ -128,6 +128,15 @@ namespace PactNet
             => this.WithJsonBody(body, settings, contentType);
 
         /// <summary>
+        /// A pre-formatted body which should be used as-is for the request 
+        /// </summary>
+        /// <param name="body">Request body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV2 IRequestBuilderV2.WithBody(string body, string contentType)
+            => this.WithBody(body, contentType);
+
+        /// <summary>
         /// Define the response to this request
         /// </summary>
         /// <returns>Response builder</returns>
@@ -236,6 +245,15 @@ namespace PactNet
         /// <returns>Fluent builder</returns>
         IRequestBuilderV3 IRequestBuilderV3.WithJsonBody(dynamic body, JsonSerializerSettings settings, string contentType)
             => this.WithJsonBody(body, settings, contentType);
+
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the request 
+        /// </summary>
+        /// <param name="body">Request body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IRequestBuilderV3 IRequestBuilderV3.WithBody(string body, string contentType)
+            => this.WithBody(body, contentType);
 
         /// <summary>
         /// Define the response to this request
@@ -374,8 +392,18 @@ namespace PactNet
         internal RequestBuilder WithJsonBody(dynamic body, JsonSerializerSettings settings, string contentType)
         {
             string serialised = JsonConvert.SerializeObject(body, settings);
+            return this.WithBody(serialised, contentType);
+        }
 
-            this.server.WithRequestBody(this.interaction, contentType, serialised);
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the request 
+        /// </summary>
+        /// <param name="body">Request body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        internal RequestBuilder WithBody(string body, string contentType)
+        {
+            this.server.WithRequestBody(this.interaction, contentType, body);
             return this;
         }
 

--- a/src/PactNet/ResponseBuilder.cs
+++ b/src/PactNet/ResponseBuilder.cs
@@ -84,6 +84,15 @@ namespace PactNet
         IResponseBuilderV2 IResponseBuilderV2.WithJsonBody(dynamic body, JsonSerializerSettings settings)
             => this.WithJsonBody(body, settings);
 
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the response 
+        /// </summary>
+        /// <param name="body">Response body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IResponseBuilderV2 IResponseBuilderV2.WithBody(string body, string contentType)
+            => this.WithBody(body, contentType);
+
         #endregion
 
         #region IResponseBuilderV3 explicit implementation
@@ -138,6 +147,15 @@ namespace PactNet
         /// <returns>Fluent builder</returns>
         IResponseBuilderV3 IResponseBuilderV3.WithJsonBody(dynamic body, JsonSerializerSettings settings)
             => this.WithJsonBody(body, settings);
+
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the response 
+        /// </summary>
+        /// <param name="body">Response body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        IResponseBuilderV3 IResponseBuilderV3.WithBody(string body, string contentType)
+            => this.WithBody(body, contentType);
 
         #endregion
 
@@ -211,8 +229,18 @@ namespace PactNet
         internal ResponseBuilder WithJsonBody(dynamic body, JsonSerializerSettings settings)
         {
             string serialised = JsonConvert.SerializeObject(body, settings);
+            return this.WithBody(serialised, "application/json");
+        }
 
-            this.server.WithResponseBody(this.interaction, "application/json", serialised);
+        /// <summary>
+        /// A pre-formatted body which should be used as-is for the response 
+        /// </summary>
+        /// <param name="body">Response body</param>
+        /// <param name="contentType">Content type</param>
+        /// <returns>Fluent builder</returns>
+        internal ResponseBuilder WithBody(string body, string contentType)
+        {
+            this.server.WithResponseBody(this.interaction, contentType, body);
             return this;
         }
     }

--- a/tests/PactNet.Tests/RequestBuilderTests.cs
+++ b/tests/PactNet.Tests/RequestBuilderTests.cs
@@ -179,6 +179,14 @@ namespace PactNet.Tests
         }
 
         [Fact]
+        public void WithBody_WhenCalled_AddsRequestBody()
+        {
+            this.builder.WithBody("foo,bar\nbaz,bash", "text/csv");
+
+            this.mockServer.Verify(s => s.WithRequestBody(this.handle, "text/csv", "foo,bar\nbaz,bash"));
+        }
+
+        [Fact]
         public void WillRespond_RequestConfigured_ReturnsResponseBuilder()
         {
             this.builder.WithRequest(HttpMethod.Delete, "/foo");

--- a/tests/PactNet.Tests/ResponseBuilderTests.cs
+++ b/tests/PactNet.Tests/ResponseBuilderTests.cs
@@ -111,5 +111,13 @@ namespace PactNet.Tests
 
             this.mockServer.Verify(s => s.WithResponseBody(this.handle, "application/json", @"{""foo"":42}"));
         }
+
+        [Fact]
+        public void WithBody_WhenCalled_AddsRequestBody()
+        {
+            this.builder.WithBody("foo,bar\nbaz,bash", "text/csv");
+
+            this.mockServer.Verify(s => s.WithResponseBody(this.handle, "text/csv", "foo,bar\nbaz,bash"));
+        }
     }
 }


### PR DESCRIPTION
Quite a simple change to just pass through some text as-is to use as the request or response body. The existing JSON methods can just run the serialiser and then pass the string result to the plain text version, so this is totally backwards compatible.

It would've been nice to use `Span<char>` instead of string, but since we're on `netstandard2.0` then that's not available.