### PR TITLE
chore: Upgrade FFI to version 0.3.11

### DIFF
--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FFI_VERSION="0.3.8"
+FFI_VERSION="0.3.11"
 FFI_BASE_URL="https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$FFI_VERSION"
 
 GREEN="\e[32m"

--- a/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
+++ b/samples/EventApi/Consumer.Tests/pacts/Event API Consumer-Event API.json
@@ -240,8 +240,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/samples/Messaging/Consumer.Tests/pacts/Stock Event Consumer-Stock Event Producer.json
+++ b/samples/Messaging/Consumer.Tests/pacts/Stock Event Consumer-Stock Event Producer.json
@@ -62,8 +62,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/samples/ReadMe/pacts/Something API Consumer-Something API.json
+++ b/samples/ReadMe/pacts/Something API Consumer-Something API.json
@@ -32,8 +32,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v2-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v2-consumer-integration.json
@@ -74,8 +74,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/tests/PactNet.Tests/data/v3-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v3-consumer-integration.json
@@ -132,8 +132,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v3-message-consumer-integration.json
+++ b/tests/PactNet.Tests/data/v3-message-consumer-integration.json
@@ -36,8 +36,8 @@
       "language": "C#"
     },
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v3-message-integration.json
+++ b/tests/PactNet.Tests/data/v3-message-integration.json
@@ -16,8 +16,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/tests/PactNet.Tests/data/v3-server-integration.json
+++ b/tests/PactNet.Tests/data/v3-server-integration.json
@@ -46,8 +46,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.8",
-      "models": "0.4.4"
+      "ffi": "0.3.11",
+      "models": "0.4.5"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
Upgraded FFI Version to 0.3.11. All tests passing locally. This version of FFI includes a fix for #417 