### PR TITLE
Testing regex in response header doesn't seem to work

### DIFF
--- a/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -285,5 +285,23 @@ namespace Consumer.Tests
                 result.Should().BeEquivalentTo(expected);
             });
         }
+
+        [Fact]
+        public async Task Verify_regex_in_response_header()
+        {
+            this.pact
+                .UponReceiving("any request")
+                    .WithRequest(HttpMethod.Get, "/test-regex-in-response-header")
+                    .WithHeader("Accept", "application/json")
+                .WillRespond()
+                    .WithStatus(HttpStatusCode.OK)
+                    .WithHeader("RegexHeader", Match.Regex("consumervalue", "^[a-z]$"));
+
+            await this.pact.VerifyAsync(async ctx =>
+            {
+                var client = new EventsApiClient(ctx.MockServerUri, Token);
+                IEnumerable<Event> events = await client.TestRegexInResponseHeader();
+            });
+        }
     }
 }

--- a/samples/EventApi/Consumer/EventsApiClient.cs
+++ b/samples/EventApi/Consumer/EventsApiClient.cs
@@ -217,6 +217,26 @@ namespace Consumer
             }
         }
 
+        public async Task<IEnumerable<Event>> TestRegexInResponseHeader()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/test-regex-in-response-header");
+            request.Headers.Add("Accept", "application/json");
+
+            var response = await this.httpClient.SendAsync(request);
+
+            try
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                    await RaiseResponseError(request, response);
+            }
+            finally
+            {
+                Dispose(request, response);
+            }
+
+            return null;
+        }
+
         private static async Task RaiseResponseError(HttpRequestMessage failedRequest, HttpResponseMessage failedResponse)
         {
             throw new HttpRequestException(

--- a/samples/EventApi/Provider/Startup.cs
+++ b/samples/EventApi/Provider/Startup.cs
@@ -79,6 +79,11 @@ namespace Provider
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapGet("/test-regex-in-response-header", async context =>
+                {
+                    context.Response.StatusCode = 200;
+                    context.Response.Headers.Add("RegexHeader", "validprovidervalue");
+                });
             });
         }
     }


### PR DESCRIPTION
Hi!

I added a test to check the verification of regex in response headers.

In the test the consumer is waiting for a response header called "RegexHeader" with any value matching "^[a-z]$".

Then the provider is returning "validprovidervalue" so it should be validated. But locally it fails. I wanted to confirm whether it could be an issue.

Thanks for your time :)