### PR TITLE
Regex in response header seems not to work with V3 specification

### DIFF
--- a/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -19,7 +19,7 @@ namespace Consumer.Tests
     {
         private const string Token = "SomeValidAuthToken";
 
-        private readonly IPactBuilderV2 pact;
+        private readonly IPactBuilderV3 pact;
 
         public EventsApiConsumerTests(ITestOutputHelper output)
         {
@@ -36,7 +36,7 @@ namespace Consumer.Tests
                 }
             };
 
-            IPactV2 pact = Pact.V2("Event API Consumer", "Event API", config);
+            IPactV3 pact = Pact.V3("Event API Consumer", "Event API", config);
             this.pact = pact.WithHttpInteractions();
         }
 
@@ -295,7 +295,7 @@ namespace Consumer.Tests
                     .WithHeader("Accept", "application/json")
                 .WillRespond()
                     .WithStatus(HttpStatusCode.OK)
-                    .WithHeader("RegexHeader", Match.Regex("consumervalue", "^[a-z]$"));
+                    .WithHeader("regexheader", Match.Regex("consumervalue", "^[a-z]+$"));
 
             await this.pact.VerifyAsync(async ctx =>
             {

--- a/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
+++ b/samples/EventApi/Consumer.Tests/EventsApiConsumerTests.cs
@@ -285,5 +285,23 @@ namespace Consumer.Tests
                 result.Should().BeEquivalentTo(expected);
             });
         }
+
+        [Fact]
+        public async Task Verify_regex_in_response_header()
+        {
+            this.pact
+                .UponReceiving("any request")
+                    .WithRequest(HttpMethod.Get, "/test-regex-in-response-header")
+                    .WithHeader("Accept", "application/json")
+                .WillRespond()
+                    .WithStatus(HttpStatusCode.OK)
+                    .WithHeader("RegexHeader", Match.Regex("consumervalue", "^[a-z]$"));
+
+            await this.pact.VerifyAsync(async ctx =>
+            {
+                var client = new EventsApiClient(ctx.MockServerUri, Token);
+                IEnumerable<Event> events = await client.TestRegexInResponseHeader();
+            });
+        }
     }
 }

--- a/samples/EventApi/Consumer/EventsApiClient.cs
+++ b/samples/EventApi/Consumer/EventsApiClient.cs
@@ -217,6 +217,26 @@ namespace Consumer
             }
         }
 
+        public async Task<IEnumerable<Event>> TestRegexInResponseHeader()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/test-regex-in-response-header");
+            request.Headers.Add("Accept", "application/json");
+
+            var response = await this.httpClient.SendAsync(request);
+
+            try
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                    await RaiseResponseError(request, response);
+            }
+            finally
+            {
+                Dispose(request, response);
+            }
+
+            return null;
+        }
+
         private static async Task RaiseResponseError(HttpRequestMessage failedRequest, HttpResponseMessage failedResponse)
         {
             throw new HttpRequestException(

--- a/samples/EventApi/Provider.Tests/EventAPITests.cs
+++ b/samples/EventApi/Provider.Tests/EventAPITests.cs
@@ -25,7 +25,7 @@ namespace Provider.Tests
         {
             var config = new PactVerifierConfig
             {
-                LogLevel = PactLogLevel.Information,
+                LogLevel = PactLogLevel.Trace,
                 Outputters = new List<IOutput>
                 {
                     new XUnitOutput(this.output)

--- a/samples/EventApi/Provider/Startup.cs
+++ b/samples/EventApi/Provider/Startup.cs
@@ -79,6 +79,11 @@ namespace Provider
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapGet("/test-regex-in-response-header", async context =>
+                {
+                    context.Response.StatusCode = 200;
+                    context.Response.Headers.Add("RegexHeader", "validprovidervalue");
+                });
             });
         }
     }

--- a/samples/EventApi/Provider/Startup.cs
+++ b/samples/EventApi/Provider/Startup.cs
@@ -82,7 +82,7 @@ namespace Provider
                 endpoints.MapGet("/test-regex-in-response-header", async context =>
                 {
                     context.Response.StatusCode = 200;
-                    context.Response.Headers.Add("RegexHeader", "validprovidervalue");
+                    context.Response.Headers.Add("regexheader", "validprovidervalue");
                 });
             });
         }


### PR DESCRIPTION
Hi :)

I updated the pact version to 3 and now the issue seems to reproduce.

![image](https://user-images.githubusercontent.com/57623565/208362036-9ba33ade-8734-4a45-b81d-30100ce546a9.png)


I'll post now the log with trace level.