### PR TITLE
feat: Support provider state teardown requests (#421)

### DIFF
--- a/samples/ReadMe/Provider.Tests/ProviderState.cs
+++ b/samples/ReadMe/Provider.Tests/ProviderState.cs
@@ -2,6 +2,12 @@ namespace ReadMe.Provider.Tests
 {
     public class ProviderState
     {
+        public enum StateAction
+        {
+            Setup, Teardown
+        }
+
         public string State { get; set; }
+        public StateAction Action { get; set; }
     }
 }

--- a/samples/ReadMe/Provider.Tests/SomethingApiFixture.cs
+++ b/samples/ReadMe/Provider.Tests/SomethingApiFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -26,12 +25,6 @@ namespace ReadMe.Provider.Tests
         public void Dispose()
         {
             server.Dispose();
-
-            // Clean out leftover data
-            foreach (var dataFile in Directory.GetFiles(Path.Combine("..", "..", "..", "data")))
-            {
-                File.Delete(dataFile);
-            }
         }
     }
 }

--- a/src/PactNet.Abstractions/Verifier/IPactVerifierSource.cs
+++ b/src/PactNet.Abstractions/Verifier/IPactVerifierSource.cs
@@ -16,6 +16,15 @@ namespace PactNet.Verifier
         IPactVerifierSource WithProviderStateUrl(Uri providerStateUri);
 
         /// <summary>
+        /// Set up the provider state setup URL so the service can configure states
+        /// </summary>
+        /// <param name="providerStateUri">Provider state setup URI</param>
+        /// <param name="teardown">Sets if teardown state change requests should be made after an interaction is validated</param>
+        /// <param name="body">Sets if state change request data should be sent in the body (true) or as query parameters (false)</param>
+        /// <returns>Fluent builder</returns>
+        IPactVerifierSource WithProviderStateUrl(Uri providerStateUri, bool teardown, bool body);
+
+        /// <summary>
         /// Filter the interactions to only those matching the given description and/or provider state
         /// </summary>
         /// <param name="description">Interaction description. All interactions are verified if this is null</param>

--- a/src/PactNet/Verifier/PactVerifierSource.cs
+++ b/src/PactNet/Verifier/PactVerifierSource.cs
@@ -33,10 +33,21 @@ namespace PactNet.Verifier
         /// <returns>Fluent builder</returns>
         public IPactVerifierSource WithProviderStateUrl(Uri providerStateUri)
         {
+            return WithProviderStateUrl(providerStateUri, false, true);
+        }
+
+        /// <summary>
+        /// Set up the provider state setup URL so the service can configure states
+        /// </summary>
+        /// <param name="providerStateUri">Provider state setup URI</param>
+        /// <param name="teardown">Sets if teardown state change requests should be made after an interaction is validated</param>
+        /// <param name="body">Sets if state change request data should be sent in the body (true) or as query parameters (false)</param>
+        /// <returns>Fluent builder</returns>
+        public IPactVerifierSource WithProviderStateUrl(Uri providerStateUri, bool teardown, bool body)
+        {
             Guard.NotNull(providerStateUri, nameof(providerStateUri));
 
-            // TODO: Support teardowns and disabling provider state bodies
-            this.provider.SetProviderState(providerStateUri, false, true);
+            this.provider.SetProviderState(providerStateUri, teardown, body);
 
             return this;
         }

--- a/tests/PactNet.Tests/Verifier/PactVerifierSourceTests.cs
+++ b/tests/PactNet.Tests/Verifier/PactVerifierSourceTests.cs
@@ -40,6 +40,26 @@ namespace PactNet.Tests.Verifier
         }
 
         [Fact]
+        public void WithProviderStateUrl_WhenCalled_WithBodyDisabled_SetsProviderStatePath()
+        {
+            var uri = new Uri("http://example.org/provider/state/path/");
+
+            this.verifier.WithProviderStateUrl(uri, false, false);
+
+            this.mockProvider.Verify(p => p.SetProviderState(uri, false, false));
+        }
+
+        [Fact]
+        public void WithProviderStateUrl_WhenCalled_WithTeardownEnabled_SetsProviderStatePath()
+        {
+            var uri = new Uri("http://example.org/provider/state/path/");
+
+            this.verifier.WithProviderStateUrl(uri, true, true);
+
+            this.mockProvider.Verify(p => p.SetProviderState(uri, true, true));
+        }
+
+        [Fact]
         public void WithFilter_WhenCalled_SetsFilterInfo()
         {
             this.verifier.WithFilter("description", "provider state");


### PR DESCRIPTION
Adding support for provider state teardown requests and state sent as query params.

This is based on #422. 