### PR TITLE
feat: WithQuery overload with matcher parameter

### DIFF
--- a/src/PactNet.Abstractions/IRequestBuilder.cs
+++ b/src/PactNet.Abstractions/IRequestBuilder.cs
@@ -151,6 +151,15 @@ namespace PactNet
         IRequestBuilderV3 WithQuery(string key, string value);
 
         /// <summary>
+        /// Add a query parameter matcher
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="matcher">Query parameter matcher</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        IRequestBuilderV3 WithQuery(string key, IMatcher matcher);
+
+        /// <summary>
         /// Add a request header
         /// </summary>
         /// <param name="key">Header key</param>

--- a/src/PactNet/RequestBuilder.cs
+++ b/src/PactNet/RequestBuilder.cs
@@ -190,6 +190,16 @@ namespace PactNet
             => this.WithQuery(key, value);
 
         /// <summary>
+        /// Add a query parameter matcher
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="matcher">Query parameter matcher</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        IRequestBuilderV3 IRequestBuilderV3.WithQuery(string key, IMatcher matcher)
+            => this.WithQuery(key, matcher);
+
+        /// <summary>
         /// Add a request header
         /// </summary>
         /// <param name="key">Header key</param>
@@ -325,6 +335,20 @@ namespace PactNet
 
             this.driver.WithQueryParameter(key, value, index);
             return this;
+        }
+
+        /// <summary>
+        /// Add a query parameter matcher
+        /// </summary>
+        /// <param name="key">Query parameter key</param>
+        /// <param name="matcher">Query parameter matcher</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>You can add a query parameter with the same key multiple times</remarks>
+        internal RequestBuilder WithQuery(string key, IMatcher matcher)
+        {
+            var serialised = JsonConvert.SerializeObject(matcher, this.defaultSettings);
+
+            return this.WithQuery(key, serialised);
         }
 
         /// <summary>

--- a/tests/PactNet.Tests/RequestBuilderTests.cs
+++ b/tests/PactNet.Tests/RequestBuilderTests.cs
@@ -87,6 +87,16 @@ namespace PactNet.Tests
         }
 
         [Fact]
+        public void WithQuery_Matcher_WhenCalled_AddsSerialisedQueryParameter()
+        {
+            var expectedValue = "{\"pact:matcher:type\":\"regex\",\"value\":\"queryParameter\",\"regex\":\"^queryParameter$\"}";
+
+            this.builder.WithQuery("name", Match.Regex("queryParameter", "^queryParameter$"));
+
+            this.mockDriver.Verify(s => s.WithQueryParameter("name", expectedValue, 0));
+        }
+
+        [Fact]
         public void WithHeader_Matcher_WhenCalled_AddsSerialisedHeaderParam()
         {
             var expectedValue = "{\"pact:matcher:type\":\"regex\",\"value\":\"header\",\"regex\":\"^header$\"}";


### PR DESCRIPTION
Add a WithQuery overload `WithQuery(string key, IMatcher matcher)`, similar to `WithHeader(string key, IMatcher matcher)`