### PR TITLE
fix(#468): Allow non-ASCII chars on most user input

### DIFF
--- a/src/PactNet/Drivers/AbstractPactDriver.cs
+++ b/src/PactNet/Drivers/AbstractPactDriver.cs
@@ -27,7 +27,7 @@ namespace PactNet.Drivers
         /// <exception cref="InvalidOperationException">Failed to write pact file</exception>
         public void WritePactFile(string directory)
         {
-            var result = NativeInterop.WritePactFile(this.pact, directory, false);
+            var result = NativeInterop.WritePactFile(this.pact, NativeInterop.StringToUtf8(directory), false);
 
             if (result != 0)
             {

--- a/src/PactNet/Drivers/HttpInteractionDriver.cs
+++ b/src/PactNet/Drivers/HttpInteractionDriver.cs
@@ -28,7 +28,7 @@ namespace PactNet.Drivers
         /// <param name="description">Provider state description</param>
         /// <returns>Success</returns>
         public void Given(string description)
-            => NativeInterop.Given(this.interaction, description).CheckInteropSuccess();
+            => NativeInterop.Given(this.interaction, NativeInterop.StringToUtf8(description)).CheckInteropSuccess();
 
         /// <summary>
         /// Add a provider state with a parameter to the interaction
@@ -38,7 +38,11 @@ namespace PactNet.Drivers
         /// <param name="value">Parameter value</param>
         /// <returns>Success</returns>
         public void GivenWithParam(string description, string name, string value)
-            => NativeInterop.GivenWithParam(this.interaction, description, name, value).CheckInteropSuccess();
+            => NativeInterop.GivenWithParam(this.interaction,
+                                            NativeInterop.StringToUtf8(description),
+                                            NativeInterop.StringToUtf8(name),
+                                            NativeInterop.StringToUtf8(value))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Add a request to the interaction
@@ -46,7 +50,9 @@ namespace PactNet.Drivers
         /// <param name="method">Request method</param>
         /// <param name="path">Request path</param>
         public void WithRequest(string method, string path)
-            => NativeInterop.WithRequest(this.interaction, method, path).CheckInteropSuccess();
+            => NativeInterop
+              .WithRequest(this.interaction, method, path)
+              .CheckInteropSuccess();
 
         /// <summary>
         /// Add a query string parameter to the interaction
@@ -55,7 +61,11 @@ namespace PactNet.Drivers
         /// <param name="value">Parameter value</param>
         /// <param name="index">Parameter index (for if the same name is used multiple times)</param>
         public void WithQueryParameter(string name, string value, uint index)
-            => NativeInterop.WithQueryParameter(this.interaction, name, new UIntPtr(index), value).CheckInteropSuccess();
+            => NativeInterop.WithQueryParameter(this.interaction,
+                                                NativeInterop.StringToUtf8(name),
+                                                new UIntPtr(index),
+                                                NativeInterop.StringToUtf8(value))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Set a request header
@@ -64,7 +74,12 @@ namespace PactNet.Drivers
         /// <param name="value">Header value</param>
         /// <param name="index">Header index (for if the same header is added multiple times)</param>
         public void WithRequestHeader(string name, string value, uint index)
-            => NativeInterop.WithHeader(this.interaction, InteractionPart.Request, name, new UIntPtr(index), value).CheckInteropSuccess();
+            => NativeInterop.WithHeader(this.interaction,
+                                        InteractionPart.Request,
+                                        NativeInterop.StringToUtf8(name),
+                                        new UIntPtr(index),
+                                        NativeInterop.StringToUtf8(value))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Set a response header
@@ -73,7 +88,12 @@ namespace PactNet.Drivers
         /// <param name="value">Header value</param>
         /// <param name="index">Header index (for if the same header is added multiple times)</param>
         public void WithResponseHeader(string name, string value, uint index)
-            => NativeInterop.WithHeader(this.interaction, InteractionPart.Response, name, new UIntPtr(index), value).CheckInteropSuccess();
+            => NativeInterop.WithHeader(this.interaction,
+                                        InteractionPart.Response,
+                                        NativeInterop.StringToUtf8(name),
+                                        new UIntPtr(index),
+                                        NativeInterop.StringToUtf8(value))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Set the response status
@@ -88,7 +108,11 @@ namespace PactNet.Drivers
         /// <param name="contentType">Context type</param>
         /// <param name="body">Serialised body</param>
         public void WithRequestBody(string contentType, string body)
-            => NativeInterop.WithBody(this.interaction, InteractionPart.Request, contentType, body).CheckInteropSuccess();
+            => NativeInterop.WithBody(this.interaction,
+                                      InteractionPart.Request,
+                                      NativeInterop.StringToUtf8(contentType),
+                                      NativeInterop.StringToUtf8(body))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Set the response body
@@ -96,6 +120,10 @@ namespace PactNet.Drivers
         /// <param name="contentType">Context type</param>
         /// <param name="body">Serialised body</param>
         public void WithResponseBody(string contentType, string body)
-            => NativeInterop.WithBody(this.interaction, InteractionPart.Response, contentType, body).CheckInteropSuccess();
+            => NativeInterop.WithBody(this.interaction,
+                                      InteractionPart.Response,
+                                      NativeInterop.StringToUtf8(contentType),
+                                      NativeInterop.StringToUtf8(body))
+                            .CheckInteropSuccess();
     }
 }

--- a/src/PactNet/Drivers/HttpPactDriver.cs
+++ b/src/PactNet/Drivers/HttpPactDriver.cs
@@ -26,7 +26,7 @@ namespace PactNet.Drivers
         /// <returns>HTTP interaction handle</returns>
         public IHttpInteractionDriver NewHttpInteraction(string description)
         {
-            InteractionHandle interaction = NativeInterop.NewInteraction(this.pact, description);
+            InteractionHandle interaction = NativeInterop.NewInteraction(this.pact, NativeInterop.StringToUtf8(description));
             return new HttpInteractionDriver(this.pact, interaction);
         }
 

--- a/src/PactNet/Drivers/MessageInteractionDriver.cs
+++ b/src/PactNet/Drivers/MessageInteractionDriver.cs
@@ -26,7 +26,7 @@ namespace PactNet.Drivers
         /// </summary>
         /// <param name="description">Provider state description</param>
         public void Given(string description)
-            => NativeInterop.Given(this.interaction, description).CheckInteropSuccess();
+            => NativeInterop.Given(this.interaction, NativeInterop.StringToUtf8(description)).CheckInteropSuccess();
 
         /// <summary>
         /// Add a provider state with a parameter to the interaction
@@ -35,14 +35,18 @@ namespace PactNet.Drivers
         /// <param name="name">Parameter name</param>
         /// <param name="value">Parameter value</param>
         public void GivenWithParam(string description, string name, string value)
-            => NativeInterop.GivenWithParam(this.interaction, description, name, value).CheckInteropSuccess();
+            => NativeInterop.GivenWithParam(this.interaction,
+                                            NativeInterop.StringToUtf8(description),
+                                            NativeInterop.StringToUtf8(name),
+                                            NativeInterop.StringToUtf8(value))
+                            .CheckInteropSuccess();
 
         /// <summary>
         /// Set the description of the message interaction
         /// </summary>
         /// <param name="description">message description</param>
         public void ExpectsToReceive(string description)
-            => NativeInterop.MessageExpectsToReceive(this.interaction, description);
+            => NativeInterop.MessageExpectsToReceive(this.interaction, NativeInterop.StringToUtf8(description));
 
         /// <summary>
         /// Set the metadata of the message
@@ -50,7 +54,7 @@ namespace PactNet.Drivers
         /// <param name="key">the key</param>
         /// <param name="value">the value</param>
         public void WithMetadata(string key, string value)
-            => NativeInterop.MessageWithMetadata(this.interaction, key, value);
+            => NativeInterop.MessageWithMetadata(this.interaction, NativeInterop.StringToUtf8(key), NativeInterop.StringToUtf8(value));
 
         /// <summary>
         /// Set the contents of the message
@@ -59,7 +63,7 @@ namespace PactNet.Drivers
         /// <param name="body">the body of the message</param>
         /// <param name="size">the size of the message</param>
         public void WithContents(string contentType, string body, uint size)
-            => NativeInterop.MessageWithContents(this.interaction, contentType, body, new UIntPtr(0));
+            => NativeInterop.MessageWithContents(this.interaction, NativeInterop.StringToUtf8(contentType), NativeInterop.StringToUtf8(body), new UIntPtr(0));
 
         /// <summary>
         /// Returns the message without the matchers

--- a/src/PactNet/Drivers/MessagePactDriver.cs
+++ b/src/PactNet/Drivers/MessagePactDriver.cs
@@ -25,7 +25,7 @@ namespace PactNet.Drivers
         /// <returns>Message interaction driver</returns>
         public IMessageInteractionDriver NewMessageInteraction(string description)
         {
-            InteractionHandle interaction = NativeInterop.NewMessageInteraction(this.pact, description);
+            InteractionHandle interaction = NativeInterop.NewMessageInteraction(this.pact, NativeInterop.StringToUtf8(description));
             return new MessageInteractionDriver(this.pact, interaction);
         }
 
@@ -36,6 +36,9 @@ namespace PactNet.Drivers
         /// <param name="name">the name of the parameter</param>
         /// <param name="value">the value of the parameter</param>
         public void WithMessagePactMetadata(string @namespace, string name, string value)
-            => NativeInterop.WithMessagePactMetadata(this.pact, @namespace, name, value);
+            => NativeInterop.WithMessagePactMetadata(this.pact,
+                                                     NativeInterop.StringToUtf8(@namespace),
+                                                     NativeInterop.StringToUtf8(name),
+                                                     NativeInterop.StringToUtf8(value));
     }
 }

--- a/src/PactNet/Drivers/PactDriver.cs
+++ b/src/PactNet/Drivers/PactDriver.cs
@@ -16,7 +16,7 @@ namespace PactNet.Drivers
         /// <returns>HTTP pact driver</returns>
         public IHttpPactDriver NewHttpPact(string consumerName, string providerName, PactSpecification version)
         {
-            PactHandle pact = NativeInterop.NewPact(consumerName, providerName);
+            PactHandle pact = NativeInterop.NewPact(NativeInterop.StringToUtf8(consumerName), NativeInterop.StringToUtf8(providerName));
             NativeInterop.WithSpecification(pact, version).CheckInteropSuccess();
 
             return new HttpPactDriver(pact);
@@ -31,7 +31,7 @@ namespace PactNet.Drivers
         /// <returns>Message pact driver driver</returns>
         public IMessagePactDriver NewMessagePact(string consumerName, string providerName, PactSpecification version)
         {
-            PactHandle pact = NativeInterop.NewPact(consumerName, providerName);
+            PactHandle pact = NativeInterop.NewPact(NativeInterop.StringToUtf8(consumerName), NativeInterop.StringToUtf8(providerName));
             NativeInterop.WithSpecification(pact, version).CheckInteropSuccess();
 
             return new MessagePactDriver(pact);

--- a/src/PactNet/Interop/NativeInterop.cs
+++ b/src/PactNet/Interop/NativeInterop.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace PactNet.Interop
 {
@@ -28,65 +29,59 @@ namespace PactNet.Interop
         public static extern bool CleanupMockServer(int mockServerPort);
 
         [DllImport(DllName, EntryPoint = "pactffi_pact_handle_write_file")]
-        public static extern int WritePactFile(PactHandle pact, string directory, bool overwrite);
+        public static extern int WritePactFile(PactHandle pact, byte[] directory, bool overwrite);
 
         [DllImport(DllName, EntryPoint = "pactffi_fetch_log_buffer")]
-        public static extern string FetchLogBuffer(string logId);
+        public static extern string FetchLogBuffer(byte[] logId);
 
         [DllImport(DllName, EntryPoint = "pactffi_new_pact")]
-        public static extern PactHandle NewPact(string consumerName, string providerName);
+        public static extern PactHandle NewPact(byte[] consumerName, byte[] providerName);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_specification")]
         public static extern bool WithSpecification(PactHandle pact, PactSpecification version);
 
         [DllImport(DllName, EntryPoint = "pactffi_new_interaction")]
-        public static extern InteractionHandle NewInteraction(PactHandle pact, string description);
+        public static extern InteractionHandle NewInteraction(PactHandle pact, byte[] description);
 
         [DllImport(DllName, EntryPoint = "pactffi_given")]
-        public static extern bool Given(InteractionHandle interaction, string description);
+        public static extern bool Given(InteractionHandle interaction, byte[] description);
 
         [DllImport(DllName, EntryPoint = "pactffi_given_with_param")]
-        public static extern bool GivenWithParam(InteractionHandle interaction, string description, string name, string value);
+        public static extern bool GivenWithParam(InteractionHandle interaction, byte[] description, byte[] name, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_request")]
         public static extern bool WithRequest(InteractionHandle interaction, string method, string path);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_query_parameter_v2")]
-        public static extern bool WithQueryParameter(InteractionHandle interaction, string name, UIntPtr index, string value);
+        public static extern bool WithQueryParameter(InteractionHandle interaction, byte[] name, UIntPtr index, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_header_v2")]
-        public static extern bool WithHeader(InteractionHandle interaction, InteractionPart part, string name, UIntPtr index, string value);
+        public static extern bool WithHeader(InteractionHandle interaction, InteractionPart part, byte[] name, UIntPtr index, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_response_status")]
         public static extern bool ResponseStatus(InteractionHandle interaction, ushort status);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_body")]
-        public static extern bool WithBody(InteractionHandle interaction, InteractionPart part, string contentType, string body);
-
-        [DllImport(DllName, EntryPoint = "pactffi_free_string")]
-        public static extern void FreeString(IntPtr s);
-
-        [DllImport(DllName, EntryPoint = "pactffi_verify")]
-        public static extern int Verify(string args);
+        public static extern bool WithBody(InteractionHandle interaction, InteractionPart part, byte[] contentType, byte[] body);
 
         #endregion Http Interop Support
 
         #region Messaging Interop Support
 
         [DllImport(DllName, EntryPoint = "pactffi_with_message_pact_metadata")]
-        public static extern void WithMessagePactMetadata(PactHandle pact, string @namespace, string name, string value);
+        public static extern void WithMessagePactMetadata(PactHandle pact, byte[] @namespace, byte[] name, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_new_message_interaction")]
-        public static extern InteractionHandle NewMessageInteraction(PactHandle pact, string description);
+        public static extern InteractionHandle NewMessageInteraction(PactHandle pact, byte[] description);
 
         [DllImport(DllName, EntryPoint = "pactffi_message_expects_to_receive")]
-        public static extern void MessageExpectsToReceive(InteractionHandle message, string description);
+        public static extern void MessageExpectsToReceive(InteractionHandle message, byte[] description);
 
         [DllImport(DllName, EntryPoint = "pactffi_message_with_metadata")]
-        public static extern void MessageWithMetadata(InteractionHandle message, string key, string value);
+        public static extern void MessageWithMetadata(InteractionHandle message, byte[] key, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_message_with_contents")]
-        public static extern void MessageWithContents(InteractionHandle message, string contentType, string body, UIntPtr size);
+        public static extern void MessageWithContents(InteractionHandle message, byte[] contentType, byte[] body, UIntPtr size);
 
         [DllImport(DllName, EntryPoint = "pactffi_message_reify")]
         public static extern IntPtr MessageReify(InteractionHandle message);
@@ -96,19 +91,19 @@ namespace PactNet.Interop
         #region Verifier Support
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_new_for_application")]
-        public static extern IntPtr VerifierNewForApplication(string name, string version);
+        public static extern IntPtr VerifierNewForApplication(byte[] name, byte[] version);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_shutdown")]
         public static extern IntPtr VerifierShutdown(IntPtr handle);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_set_provider_info")]
-        public static extern void VerifierSetProviderInfo(IntPtr handle, string name, string scheme, string host, ushort port, string path);
+        public static extern void VerifierSetProviderInfo(IntPtr handle, byte[] name, string scheme, string host, ushort port, string path);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_add_provider_transport")]
         public static extern void AddProviderTransport(IntPtr handle, string protocol, ushort port, string path, string scheme);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_set_filter_info")]
-        public static extern void VerifierSetFilterInfo(IntPtr handle, string description, string state, byte noState);
+        public static extern void VerifierSetFilterInfo(IntPtr handle, byte[] description, byte[] state, byte noState);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_set_provider_state")]
         public static extern void VerifierSetProviderState(IntPtr handle, string url, byte teardown, byte body);
@@ -120,38 +115,38 @@ namespace PactNet.Interop
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_set_publish_options")]
         public static extern void VerifierSetPublishOptions(IntPtr handle,
-                                                            string providerVersion,
-                                                            string buildUrl,
+                                                            byte[] providerVersion,
+                                                            byte[] buildUrl,
                                                             string[] providerTags,
                                                             ushort providerTagsLength,
-                                                            string providerBranch);
+                                                            byte[] providerBranch);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_set_consumer_filters")]
         public static extern void VerifierSetConsumerFilters(IntPtr handle, string[] consumerFilters, ushort consumerFiltersLength);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_add_custom_header")]
-        public static extern void AddCustomHeader(IntPtr handle, string name, string value);
+        public static extern void AddCustomHeader(IntPtr handle, byte[] name, byte[] value);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_add_file_source")]
-        public static extern void VerifierAddFileSource(IntPtr handle, string file);
+        public static extern void VerifierAddFileSource(IntPtr handle, byte[] file);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_add_directory_source")]
-        public static extern void VerifierAddDirectorySource(IntPtr handle, string directory);
+        public static extern void VerifierAddDirectorySource(IntPtr handle, byte[] directory);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_url_source")]
-        public static extern void VerifierUrlSource(IntPtr handle, string url, string username, string password, string token);
+        public static extern void VerifierUrlSource(IntPtr handle, byte[] url, byte[] username, byte[] password, byte[] token);
 
         [DllImport(DllName, EntryPoint = "pactffi_verifier_broker_source_with_selectors")]
         public static extern void VerifierBrokerSourceWithSelectors(IntPtr handle,
-                                                                    string url,
-                                                                    string username,
-                                                                    string password,
-                                                                    string token,
+                                                                    byte[] url,
+                                                                    byte[] username,
+                                                                    byte[] password,
+                                                                    byte[] token,
                                                                     byte enablePending,
                                                                     string includeWipPactsSince,
                                                                     string[] providerTags,
                                                                     ushort providerTagsLength,
-                                                                    string providerBranch,
+                                                                    byte[] providerBranch,
                                                                     string[] consumerVersionSelectors,
                                                                     ushort consumerVersionSelectorsLength,
                                                                     string[] consumerVersionTags,
@@ -168,5 +163,16 @@ namespace PactNet.Interop
         public static extern IntPtr VerifierOutput(IntPtr handle, byte stripAnsi);
 
         #endregion
+
+        public static byte[] StringToUtf8(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return Array.Empty<byte>();
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(s);
+            return bytes;
+        }
     }
 }

--- a/src/PactNet/Verifier/InteropVerifierProvider.cs
+++ b/src/PactNet/Verifier/InteropVerifierProvider.cs
@@ -42,7 +42,8 @@ namespace PactNet.Verifier
                 _ => throw new ArgumentOutOfRangeException(nameof(config.LogLevel), config.LogLevel, "Invalid log level")
             });
 
-            this.handle = NativeInterop.VerifierNewForApplication("pact-net", typeof(InteropVerifierProvider).Assembly.GetName().Version.ToString());
+            this.handle = NativeInterop.VerifierNewForApplication(NativeInterop.StringToUtf8("pact-net"),
+                                                                  NativeInterop.StringToUtf8(typeof(InteropVerifierProvider).Assembly.GetName().Version.ToString()));
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace PactNet.Verifier
         /// <param name="path">Provider URI path</param>
         public void SetProviderInfo(string name, string scheme, string host, ushort port, string path)
         {
-            NativeInterop.VerifierSetProviderInfo(this.handle, name, scheme, host, port, path);
+            NativeInterop.VerifierSetProviderInfo(this.handle, NativeInterop.StringToUtf8(name), scheme, host, port, path);
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace PactNet.Verifier
         /// <param name="noState">Filter to only interactions with (false) or without (true) provider state</param>
         public void SetFilterInfo(string description = null, string state = null, bool? noState = null)
         {
-            NativeInterop.VerifierSetFilterInfo(this.handle, description, state, ToSafeByte(noState));
+            NativeInterop.VerifierSetFilterInfo(this.handle, NativeInterop.StringToUtf8(description), NativeInterop.StringToUtf8(state), ToSafeByte(noState));
         }
 
         /// <summary>
@@ -116,11 +117,11 @@ namespace PactNet.Verifier
         public void SetPublishOptions(string providerVersion, Uri buildUrl, ICollection<string> providerTags, string providerBranch)
         {
             NativeInterop.VerifierSetPublishOptions(this.handle,
-                                                    providerVersion,
-                                                    buildUrl?.AbsoluteUri,
+                                                    NativeInterop.StringToUtf8(providerVersion),
+                                                    NativeInterop.StringToUtf8(buildUrl?.AbsoluteUri),
                                                     providerTags.ToArray(),
                                                     (ushort)providerTags.Count,
-                                                    providerBranch);
+                                                    NativeInterop.StringToUtf8(providerBranch));
         }
 
         /// <summary>
@@ -129,7 +130,9 @@ namespace PactNet.Verifier
         /// <param name="consumerFilters">Consumer filters</param>
         public void SetConsumerFilters(ICollection<string> consumerFilters)
         {
-            NativeInterop.VerifierSetConsumerFilters(this.handle, consumerFilters.ToArray(), (ushort)consumerFilters.Count);
+            NativeInterop.VerifierSetConsumerFilters(this.handle,
+                                                     consumerFilters.ToArray(),
+                                                     (ushort)consumerFilters.Count);
         }
 
         /// <summary>
@@ -141,7 +144,7 @@ namespace PactNet.Verifier
         /// <returns>Fluent builder</returns>
         public void AddCustomHeader(string name, string value)
         {
-            NativeInterop.AddCustomHeader(this.handle, name, value);
+            NativeInterop.AddCustomHeader(this.handle, NativeInterop.StringToUtf8(name), NativeInterop.StringToUtf8(value));
         }
 
         /// <summary>
@@ -150,7 +153,7 @@ namespace PactNet.Verifier
         /// <param name="file">File</param>
         public void AddFileSource(FileInfo file)
         {
-            NativeInterop.VerifierAddFileSource(this.handle, file.FullName);
+            NativeInterop.VerifierAddFileSource(this.handle, NativeInterop.StringToUtf8(file.FullName));
         }
 
         /// <summary>
@@ -160,7 +163,7 @@ namespace PactNet.Verifier
         /// <remarks>Can be used with <see cref="IVerifierProvider.SetConsumerFilters"/> to filter the files in the directory</remarks>
         public void AddDirectorySource(DirectoryInfo directory)
         {
-            NativeInterop.VerifierAddDirectorySource(this.handle, directory.FullName);
+            NativeInterop.VerifierAddDirectorySource(this.handle, NativeInterop.StringToUtf8(directory.FullName));
         }
 
         /// <summary>
@@ -172,7 +175,11 @@ namespace PactNet.Verifier
         /// <param name="token">Authentication token</param>
         public void AddUrlSource(Uri url, string username, string password, string token)
         {
-            NativeInterop.VerifierUrlSource(this.handle, url.AbsoluteUri, username, password, token);
+            NativeInterop.VerifierUrlSource(this.handle,
+                                            NativeInterop.StringToUtf8(url.AbsoluteUri),
+                                            NativeInterop.StringToUtf8(username),
+                                            NativeInterop.StringToUtf8(password),
+                                            NativeInterop.StringToUtf8(token));
         }
 
         /// <summary>
@@ -200,15 +207,15 @@ namespace PactNet.Verifier
                                     ICollection<string> consumerVersionTags)
         {
             NativeInterop.VerifierBrokerSourceWithSelectors(this.handle,
-                                                            url.AbsoluteUri,
-                                                            username,
-                                                            password,
-                                                            token,
+                                                            NativeInterop.StringToUtf8(url.AbsoluteUri),
+                                                            NativeInterop.StringToUtf8(username),
+                                                            NativeInterop.StringToUtf8(password),
+                                                            NativeInterop.StringToUtf8(token),
                                                             ToSafeByte(enablePending),
                                                             includeWipPactsSince?.ToString("yyyy-MM-dd"),
                                                             providerTags.ToArray(),
                                                             (ushort)providerTags.Count,
-                                                            providerBranch,
+                                                            NativeInterop.StringToUtf8(providerBranch),
                                                             consumerVersionSelectors.ToArray(),
                                                             (ushort)consumerVersionSelectors.Count,
                                                             consumerVersionTags.ToArray(),

--- a/tests/PactNet.Tests/Drivers/FfiIntegrationTests.cs
+++ b/tests/PactNet.Tests/Drivers/FfiIntegrationTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace PactNet.Tests.Drivers
 {
     /// <summary>
-    /// Happy path integration tests to make sure wwe're calling the Rust FFI library properly with P/Invoke
+    /// Happy path integration tests to make sure we're calling the Rust FFI library properly with P/Invoke
     /// </summary>
     public class FfiIntegrationTests
     {

--- a/tests/PactNet.Tests/data/v4-non-ascii-integration.json
+++ b/tests/PactNet.Tests/data/v4-non-ascii-integration.json
@@ -1,0 +1,117 @@
+{
+  "consumer": {
+    "name": "PactExtensioñsTests-Combined-V4"
+  },
+  "interactions": [
+    {
+      "description": "a HTTP request with non-ASCII characters like ñ",
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "a provider state with ñ"
+        },
+        {
+          "name": "another provider state with ñ"
+        },
+        {
+          "name": "a provider state with params with ñ",
+          "params": {
+            "bañ": "bash",
+            "foo": "bañ"
+          }
+        }
+      ],
+      "request": {
+        "body": {
+          "content": {
+            "foo": "ñ request"
+          },
+          "contentType": "application/json",
+          "encoded": false
+        },
+        "headers": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.foo": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/things"
+      },
+      "response": {
+        "body": {
+          "content": {
+            "foo": "ñ response"
+          },
+          "contentType": "application/json",
+          "encoded": false
+        },
+        "headers": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 201
+      },
+      "type": "Synchronous/HTTP"
+    },
+    {
+      "contents": {
+        "content": {
+          "bool": false,
+          "int": 1,
+          "string": "a description with ñ"
+        },
+        "contentType": "application/json",
+        "encoded": false
+      },
+      "description": "a message with ñ",
+      "metadata": {
+        "queueId": "1234ñ"
+      },
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "a provider state with ñ"
+        },
+        {
+          "name": "another provider state with ñ"
+        },
+        {
+          "name": "a provider state with params with ñ",
+          "params": {
+            "bañ": "bash",
+            "foo": "bañ"
+          }
+        }
+      ],
+      "type": "Asynchronous/Messages"
+    }
+  ],
+  "metadata": {
+    "framework": {
+      "language": "C#"
+    },
+    "pactRust": {
+      "ffi": "0.4.5",
+      "models": "1.1.2"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    }
+  },
+  "provider": {
+    "name": "PactExtensioñsTests-Provider"
+  }
+}


### PR DESCRIPTION
Instead of trying to marshal strings, which don't marshal nicely over the FFI boundary because C# uses UTF-16 but Rust wants UTF-8, instead explicitly convert strings to a UTF-8 `byte[]` and marshal those.

Some places don't need to allow non-ASCII, such as the scheme in URLs, whereas others are very tricky, such as consumer filters. This would change the API to `byte[][]` and those can't be marshalled, so some parts still support non-ASCII for now. If that's a problem in the future then some custom marshalling could be implemented, but currently that seems overkill.

Closes #468 