### PR TITLE
feat: support arm64 linux + ci tests for arm64 linux/macos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,48 @@
+BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
+  arch_check_script: |
+      $USE_ROSETTA uname -m
+  ffi_download_script: |
+      chmod +x build/download-native-libs.sh
+      build/download-native-libs.sh
+  restore_script: |
+      $USE_ROSETTA dotnet restore
+  build_script: |
+      $USE_ROSETTA dotnet build --no-restore
+  test_script: |
+      $USE_ROSETTA dotnet test --no-build --verbosity normal
+  pack_script: |
+      $USE_ROSETTA dotnet pack --verbosity normal -c Release --no-restore --include-source --version-suffix alpha.123 -o ./dist
+
+linux_arm64_task: 
+  arm_container:
+    image: mcr.microsoft.com/dotnet/sdk:6.0
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+linux_amd64_task: 
+  container:
+    image: mcr.microsoft.com/dotnet/sdk:6.0
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+INSTALL_DOTNET_MACOS_TEMPLATE: &INSTALL_DOTNET_MACOS_TEMPLATE
+  setup_script: |
+    $USE_ROSETTA brew tap isen-ng/dotnet-sdk-versions
+    $USE_ROSETTA brew install --cask dotnet-sdk6-0-400
+    $USE_ROSETTA dotnet --version
+
+macosx_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  env:
+    PATH: "/usr/local/share/dotnet/:$PATH"
+  << : *INSTALL_DOTNET_MACOS_TEMPLATE
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+macosx_amd64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  rosetta_script: softwareupdate --install-rosetta --agree-to-license
+  env:
+    PATH: "/usr/local/share/dotnet/x64/:$PATH"
+    USE_ROSETTA: arch -x86_64
+  << : *INSTALL_DOTNET_MACOS_TEMPLATE
+  << : *BUILD_TEST_TASK_TEMPLATE

--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -60,5 +60,6 @@ download_native() {
 
 download_native "pact_ffi" "windows" "x86_64" "dll"
 download_native "libpact_ffi" "linux" "x86_64" "so"
+download_native "libpact_ffi" "linux" "aarch64" "so"
 download_native "libpact_ffi" "osx" "x86_64" "dylib"
 download_native "libpact_ffi" "osx" "aarch64-apple-darwin" "dylib"

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -33,7 +33,14 @@
       <Link>libpact_ffi.so</Link>
       <PackagePath>runtimes/linux-x64/native</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsLinux)'">PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'False'">PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64\libpact_ffi.so">
+      <Link>libpact_ffi.so</Link>
+      <PackagePath>runtimes/linux-arm64/native</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
     <Content Include="$(MSBuildProjectDirectory)\..\..\build\osx\x86_64\libpact_ffi.dylib">


### PR DESCRIPTION


[You and whose ARMy](https://www.youtube.com/watch?v=QQnc-hM80UQ) 🦾  <-  ⚠️ YouTube link.

Introduces

- aarch64 target for linux 
- CI testing in CirrusCI for arm64 support (fixes #451)
  - MacOS M1
  - MacOS M1 with Rosetta
  - Linux aarch64/arm64
  - Linux x86_64/amd64
  
The rationale for including the x86_64 counterparts for MacOS / Linux is to eek out any inconsistencies between GHA runners and Cirrus-CI runners, and have similar base images/machines on the cirrus platform.

This should allow us to determine if there any x-plat issues are down to our CI provider, or cpu architecture (or arch emulation in the case of rosetta).
  