### PR TITLE
Add mac m1 runner to ci matrix (#451)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
+          - macos-12
           - macos-14
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest
+          - macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal -- RunConfiguration.TargetPlatform=x64
+        run: dotnet test --no-build --verbosity normal
 
       - name: Pack
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
As github recently introduced support for mac m1/m2 runners (https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), giving it a try