### PR TITLE
Added Msbuild script to download pact_ffi lib

### DIFF
--- a/PactNet.sln
+++ b/PactNet.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		build\download-native-libs.sh = build\download-native-libs.sh
+		build\Download.Native.Libs.targets = build\Download.Native.Libs.targets
 		src\NuGet.targets = src\NuGet.targets
 		README.md = README.md
 	EndProjectSection

--- a/build/Download.Native.Libs.targets
+++ b/build/Download.Native.Libs.targets
@@ -27,35 +27,35 @@
     <DownloadFile
       SourceUrl="$(FfiBaseUrl)/$(SrcFile)"
       DestinationFolder="$(DestDir)">
-      <Output TaskParameter="DownloadedFile" ItemName="DownloadLib" />
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadedLibArchive" />
     </DownloadFile>
     <DownloadFile
       SourceUrl="$(FfiBaseUrl)/$(SrcFile).sha256"
       DestinationFolder="$(DestDir)">
-      <Output TaskParameter="DownloadedFile" ItemName="DownloadLibSha256" />
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadedLibArchiveSha256" />
     </DownloadFile>
     <Message Text="Downloaded Native Lib $(SrcFile) archive" Importance="high"/>
   </Target>
-  <Target Name="VerifyDownload" AfterTargets="DownloadNativeLibraryIfNeeded" Condition="Exists(@(DownloadLibSha256))">
+  <Target Name="VerifyDownload" AfterTargets="DownloadNativeLibraryIfMissing" Condition="Exists(@(DownloadedLibArchiveSha256))">
     <Message Text="Verifying Native Lib $(SrcFile) archive" Importance="high"/>
     <PropertyGroup>
-      <DownloadedLibSha256FileContents>$([System.IO.File]::ReadAllText(%(DownloadLibSha256.Identity)))</DownloadedLibSha256FileContents>
-      <DownloadedLibSha>$(DownloadedLibSha256FileContents.Split(' ')[0].Trim())</DownloadedLibSha>
-      <VerificationFileContainsSrcFile>$(DownloadedLibSha256FileContents.Split(' ')[1].Trim().EndsWith($(SrcFile)))</VerificationFileContainsSrcFile>
+      <DownloadedLibArchiveSha256FileContents>$([System.IO.File]::ReadAllText(%(DownloadedLibArchiveSha256.Identity)))</DownloadedLibArchiveSha256FileContents>
+      <DownloadedLibArchiveSha>$(DownloadedLibArchiveSha256FileContents.Split(' ')[0].Trim())</DownloadedLibArchiveSha>
+      <VerificationFileContainsSrcFile>$(DownloadedLibArchiveSha256FileContents.Split(' ')[1].Trim().EndsWith($(SrcFile)))</VerificationFileContainsSrcFile>
     </PropertyGroup>
     <Error Text="Downloaded $(DestDir)\$(SrcFile).sha256 file is not for $(DestDir)\$(SrcFile)" Condition="$(VerificationFileContainsSrcFile) == 'False'"/>
-    <VerifyFileHash File="%(DownloadLib.Identity)"
-                    Hash="$(DownloadedLibSha)" />
+    <VerifyFileHash File="%(DownloadedLibArchive.Identity)"
+                    Hash="$(DownloadedLibArchiveSha)" />
     <Message Text="Verified Native Lib $(SrcFile) archive" Importance="high"/>
   </Target>
-  <Target Name="UnCompressArchive" AfterTargets="VerifyDownload" Condition="Exists(@(DownloadLib))">
+  <Target Name="UnCompressArchive" AfterTargets="VerifyDownload" Condition="Exists(@(DownloadedLibArchive))">
     <UnGZip
-      SourceFile="%(DownloadLib.Identity)"
+      SourceFile="%(DownloadedLibArchive.Identity)"
       DestinationFolder="$(DestDir)"
       DestinationFile="$(LibFile).$(FileExtension)"
     />
   </Target>
-  <Target Name="Cleanup" AfterTargets="UnCompressArchive" Condition="Exists(@(DownloadLib)) or Exists(@(DownloadLibSha256))">
+  <Target Name="Cleanup" AfterTargets="UnCompressArchive" Condition="Exists(@(DownloadedLibArchive)) or Exists(@(DownloadedLibArchiveSha256))">
     <ItemGroup>
       <FilesToDelete Include="$(DestDir)\$(LibFile)-$(OsName)-$(PlatformType).$(FileExtension)*"/>
     </ItemGroup>

--- a/build/Download.Native.Libs.targets
+++ b/build/Download.Native.Libs.targets
@@ -1,0 +1,112 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="DownloadNativeLibraryIfMissing">
+
+  <PropertyGroup>
+
+    <FfiVersion>0.4.5</FfiVersion>
+    <FfiBaseUrl>https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$(FfiVersion)</FfiBaseUrl>
+
+    <LibFile>libpact_ffi</LibFile>
+    <LibFile Condition="'$(IsWindows)' == 'True'">pact_ffi</LibFile>
+
+    <OsName Condition="'$(IsWindows)' == 'True'">windows</OsName>
+    <OsName Condition="'$(IsLinux)' == 'True'">linux</OsName>
+    <OsName Condition="'$(IsOSX)' == 'True'">osx</OsName>
+
+    <PlatformType>x86_64</PlatformType>
+    <PlatformType Condition="'$(IsOSX)' == 'True'">aarch64-apple-darwin</PlatformType>
+
+    <FileExtension Condition="'$(IsWindows)' == 'True'">dll</FileExtension>
+    <FileExtension Condition="'$(IsLinux)' == 'True'">so</FileExtension>
+    <FileExtension Condition="'$(IsOSX)' == 'True'">dylib</FileExtension>
+
+    <SrcFile>$(LibFile)-$(OsName)-$(PlatformType).$(FileExtension).gz</SrcFile>
+    <DestDir>$(MSBuildThisFileDirectory)\$(OsName)\$(PlatformType)</DestDir>
+  </PropertyGroup>
+  <Target Name="DownloadNativeLibraryIfMissing" BeforeTargets="PrepareForBuild" Condition="!Exists('$(DestDir)\$(LibFile).$(FileExtension)')">
+    <Message Text="Downloading Native Lib $(SrcFile) archive" Importance="high"/>
+    <DownloadFile
+      SourceUrl="$(FfiBaseUrl)/$(SrcFile)"
+      DestinationFolder="$(DestDir)">
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadLib" />
+    </DownloadFile>
+    <DownloadFile
+      SourceUrl="$(FfiBaseUrl)/$(SrcFile).sha256"
+      DestinationFolder="$(DestDir)">
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadLibSha256" />
+    </DownloadFile>
+    <Message Text="Downloaded Native Lib $(SrcFile) archive" Importance="high"/>
+  </Target>
+  <Target Name="VerifyDownload" AfterTargets="DownloadNativeLibraryIfNeeded" Condition="Exists(@(DownloadLibSha256))">
+    <Message Text="Verifying Native Lib $(SrcFile) archive" Importance="high"/>
+    <PropertyGroup>
+      <DownloadedLibSha256FileContents>$([System.IO.File]::ReadAllText(%(DownloadLibSha256.Identity)))</DownloadedLibSha256FileContents>
+      <DownloadedLibSha>$(DownloadedLibSha256FileContents.Split(' ')[0].Trim())</DownloadedLibSha>
+      <VerificationFileContainsSrcFile>$(DownloadedLibSha256FileContents.Split(' ')[1].Trim().EndsWith($(SrcFile)))</VerificationFileContainsSrcFile>
+    </PropertyGroup>
+    <Error Text="Downloaded $(DestDir)\$(SrcFile).sha256 file is not for $(DestDir)\$(SrcFile)" Condition="$(VerificationFileContainsSrcFile) == 'False'"/>
+    <VerifyFileHash File="%(DownloadLib.Identity)"
+                    Hash="$(DownloadedLibSha)" />
+    <Message Text="Verified Native Lib $(SrcFile) archive" Importance="high"/>
+  </Target>
+  <Target Name="UnCompressArchive" AfterTargets="VerifyDownload" Condition="Exists(@(DownloadLib))">
+    <UnGZip
+      SourceFile="%(DownloadLib.Identity)"
+      DestinationFolder="$(DestDir)"
+      DestinationFile="$(LibFile).$(FileExtension)"
+    />
+  </Target>
+  <Target Name="Cleanup" AfterTargets="UnCompressArchive" Condition="Exists(@(DownloadLib)) or Exists(@(DownloadLibSha256))">
+    <ItemGroup>
+      <FilesToDelete Include="$(DestDir)\$(LibFile)-$(OsName)-$(PlatformType).$(FileExtension)*"/>
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)">
+      <Output
+        TaskParameter="DeletedFiles"
+        ItemName="FilesDeleted"/>
+    </Delete>
+  </Target>
+  <UsingTask TaskName="UnGZip"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <SourceFile ParameterType="Microsoft.Build.Framework.ITaskItem"
+                  Required="true" />
+      <DestinationFolder ParameterType="Microsoft.Build.Framework.ITaskItem"
+                         Required="true" />
+      <DestinationFile ParameterType="Microsoft.Build.Framework.ITaskItem"
+                         Required="false" />
+      <Result ParameterType="Microsoft.Build.Framework.ITaskItem"
+              Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.IO.Compression" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        string compressedFileName = SourceFile.GetMetadata("FullPath");
+        string destinationFolder = DestinationFolder.GetMetadata("FullPath");
+        string decompressedFileName = Path.GetFileNameWithoutExtension(SourceFile.ItemSpec);
+        string decompressedFilePath = DestinationFile?.GetMetadata("Identity") == null 
+                                        ? Path.Combine(destinationFolder,decompressedFileName)
+                                        : Path.Combine(destinationFolder,DestinationFile.GetMetadata("Identity") );
+
+        Log.LogMessage(MessageImportance.High, 
+                $"Decompressing {compressedFileName} to {decompressedFilePath}");
+
+        using (var compressedFileStream = File.Open(compressedFileName, FileMode.Open))
+        using (var outputFileStream = File.Create(decompressedFilePath))
+        using (var decompressor = new GZipStream(compressedFileStream, 
+          CompressionMode.Decompress))
+        {
+            decompressor.CopyTo(outputFileStream);
+        }
+        Log.LogMessage(MessageImportance.High, 
+                $"Sucessfully decompressed {compressedFileName} to {decompressedFilePath}");
+        var destinationItem = new TaskItem(decompressedFilePath);
+              
+        Result = destinationItem;
+    ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <Import Project="../NuGet.targets" />
+  
 
   <PropertyGroup>
     <IsWindows>False</IsWindows>
@@ -20,6 +21,8 @@
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'True'">True</IsOSX>
     <IsArm64 Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">True</IsArm64>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildProjectDirectory)\..\..\build\Download.Native.Libs.targets"/>
 
   <ItemGroup>
     <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_ffi.dll">


### PR DESCRIPTION
Hey there, I justed added Download.Native.Libs.targets, it downloads the correct pact_ffi lib needed and is part of the build process instead of using download-native-libs.sh seperatily

The Download.Native.Libs.targets contains properties matching the variables in download-native-libs.sh, some renamed as to not conflict with defined MsBuild properties and some  derived from properties in the main PacNet proj file. It also contains
five tasks

*  **DownloadNativeLibraryIfMissing** which runs before **PrepareForBuild** and _**only**_ if the  pact_ffi lib file is missing.
It uses the [DownloadFile Task](https://learn.microsoft.com/en-us/visualstudio/msbuild/downloadfile-task?view=vs-2022) (Available in VS2022) to download the appropriate lib file archive and sha256 for OS, Architecture etc.
*  **VerifyDownload** which runs after **DownloadNativeLibraryIfNeeded** and only if the downloaded sha256 file exists
It reads the file hash and file name from the downloaded sha256, then it verifies that file name matches the downloaded file name. Then, it uses the [VerifyFileHash Task](https://learn.microsoft.com/en-us/visualstudio/msbuild/verifyfilehash-task?view=vs-2022) (Available in VS2022) to verify the downloaded lib file archive against the hash.
* **UnCompressArchive** which runs after **VerifyDownload** and only if the downloaded  lib file archive exists.
It decompresses the downloaded  lib file archive into the required  pact_ffi lib file
* **Cleanup** which runs after **UnCompressArchive** and only if downloaded files exist
It deletes any downloaded files
* **UnGZip** this uses some c# code to uncompress the gzip file, using standard c# libraries. There is an unzip task in msbuild, but it doesn't work with gzip format
