### PR TITLE
Improve target frameworks and their package references:

### DIFF
--- a/src/PactNet.Abstractions/PactNet.Abstractions.csproj
+++ b/src/PactNet.Abstractions/PactNet.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591;NU5105</NoWarn>
@@ -9,10 +9,9 @@
   </PropertyGroup>
 
   <Import Project="../NuGet.targets" />
-
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
+
 </Project>

--- a/src/PactNet.Output.Xunit/PactNet.Output.Xunit.csproj
+++ b/src/PactNet.Output.Xunit/PactNet.Output.Xunit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591;NU5105</NoWarn>

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>NU5105</NoWarn>
@@ -52,18 +52,6 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\PactNet.targets">
-      <PackagePath>build/net462/</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\PactNet.targets">
-      <PackagePath>buildTransitive/net462/</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </Content>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PactNet.Abstractions\PactNet.Abstractions.csproj" />

--- a/tests/PactNet.Abstractions.Tests/PactNet.Abstractions.Tests.csproj
+++ b/tests/PactNet.Abstractions.Tests/PactNet.Abstractions.Tests.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
+    <TargetFrameworks>
       net8.0
     </TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      net8.0;net462
-    </TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/PactNet.Tests/PactNet.Tests.csproj
+++ b/tests/PactNet.Tests/PactNet.Tests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">
+    <TargetFrameworks>
       net8.0
-    </TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
-      net8.0;net462
     </TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -16,12 +13,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
@@ -42,5 +33,4 @@
     <ProjectReference Include="..\..\src\PactNet.Output.Xunit\PactNet.Output.Xunit.csproj" />
     <ProjectReference Include="..\..\src\PactNet\PactNet.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Hi @adamrodger,

sorry for PR before creating an issue to discuss.
I think it is easier to discuss it within PR, if you are interested in this change.

1.) Add net8.0 as a target framework to support latest LTS version and to use latest compile improvements with less package references 
2.) Add conditions for package references => net8.0 doesn't need them 
3.) Remove net462 => netstandard2.0 is already a compatibility mode framework to support all .NET versions. There is no need to specify old .NET frameworks.
4.) All projects except nuget projects can reference only net8.0. There is no need for multiple target frameworks