### PR TITLE
feat: support linux-arm64 runtime (libc)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ version by executing the script in Bash (or Git Bash on Windows):
 build/download-native-libs.sh
 ```
 
-Alternatively you can download a particular FFI version from the [pact-referece] releases or build your own version
+Alternatively you can download a particular FFI version from the [pact-reference] releases or build your own version
 locally, and then copy the artifacts into the folders:
 
 ```
@@ -67,8 +67,10 @@ build/
     linux/
         x86_64/
             libpact_ffi.so
+        aarch64/
+            libpact_ffi.so
     osx/
-        aarch64-apple-darwin/
+        aarch64/
             libpact_ffi.dylib
         x86_64/
             libpact_ffi.dylib

--- a/README.md
+++ b/README.md
@@ -232,16 +232,16 @@ For writing messaging pacts instead of requests/response pacts, see the [messagi
 
 Due to using a shared native library instead of C# for the main Pact logic only certain OSs are supported:
 
-| OS           | Arch        | Support                                                            |
-| ------------ | ----------- | -------------------------------------------------------------------|
-| Windows      | x86         | ❌ No                                                              |
-| Windows      | x64         | ✔️ Yes                                                             |
-| Linux (libc) | ARM         | ❌ No                                                              |
-| Linux (libc) | x86         | ❌ No                                                              |
-| Linux (libc) | x64         | ✔️ Yes                                                             |
-| Linux (musl) | Any         | ❌ [No](https://github.com/pact-foundation/pact-net/issues/374)    |
-| OSX          | x64         | ✔️ Yes                                                             |
-| OSX          | ARM (M1/M2) | ✔️ Yes                                                             |
+| OS           | Arch         | Support                                                            |
+| ------------ | ------------ | -------------------------------------------------------------------|
+| Windows      | x86          | ❌ No                                                              |
+| Windows      | x64          | ✔️ Yes                                                             |
+| Linux (libc) | ARM64        | ✔️ Yes                                                              |
+| Linux (libc) | x64          | ✔️ Yes                                                             |
+| Linux (libc) | x86          | ❌ No                                                              |
+| Linux (musl) | Any          | ❌ [No](https://github.com/pact-foundation/pact-net/issues/374)    |
+| OSX          | x64          | ✔️ Yes                                                             |
+| OSX          | ARM64 (M1/M2)| ✔️ Yes                                                             |
 
 ### Pact Specification
 

--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -64,6 +64,7 @@ download_native() {
 
 download_native "pact_ffi" "windows" "x86_64" "dll"
 download_native "libpact_ffi" "linux" "x86_64" "so"
+download_native "libpact_ffi" "linux" "aarch64" "so"
 download_native "libpact_ffi" "macos" "x86_64" "dylib"
 download_native "libpact_ffi" "macos" "aarch64" "dylib"
 

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -33,7 +33,14 @@
       <Link>libpact_ffi.so</Link>
       <PackagePath>runtimes/linux-x64/native</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsLinux)'">PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'False'">PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64\libpact_ffi.so">
+      <Link>libpact_ffi.so</Link>
+      <PackagePath>runtimes/linux-arm64/native</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
     <Content Include="$(MSBuildProjectDirectory)\..\..\build\macos\x86_64\libpact_ffi.dylib">


### PR DESCRIPTION
Adds `libpact_ffi-linux-aarch64.so.gz` to support `linux-arm64` .NET target

Note: Unable to test via GitHub Actions until later in the year. [Source](https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/), although this has been validated both locally, and in CI systems (cirrus-ci)

Quote

> We expect to begin offering Arm runners for open source projects by the end of the year

This is advantageous for Docker users utilising Apple Silicon Mac's, as they are unable to leverage qemu for x64 binaries, as this is unsupported in .NET

Split out from #502 to only cover linux-aarch64(libc) case

It would be really nice if this managed to make the cut for the pact-net v5 release 🙏🏾 