### PR TITLE
chore(docs): mark pact-net 5.x as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Due to using a shared native library instead of C# for the main Pact logic only 
 
 | Version | Status     | [Spec] Compatibility | Install            |
 | ------- | ---------- | -------------------- | ------------------ |
-| 5.x     | Beta       | 2, 3, 4              | See [installation] |
+| 5.x     | Stable     | 2, 3, 4              | See [installation] |
 | 4.x     | Stable     | 2, 3                 | See [installation] |
 | 3.x     | Deprecated | 2                    |                    |
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Due to using a shared native library instead of C# for the main Pact logic only 
 | Version | Status     | [Spec] Compatibility | Install            |
 | ------- | ---------- | -------------------- | ------------------ |
 | 5.x     | Stable     | 2, 3, 4              | See [installation] |
-| 4.x     | Stable     | 2, 3                 | See [installation] |
+| 4.x     | Deprecated | 2, 3                 | See [installation] |
 | 3.x     | Deprecated | 2                    |                    |
 
 ## Roadmap


### PR DESCRIPTION
Should 4.x be marked as deprecated, or is that still supported for a certain period of time, to allow for migration to 4.x and potentially allow for changes/fixes to be released to the 4.x line?