### PR TITLE
ci: add ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           - arch: x64
           - arch: ARM64
             os: macos-14
+          - arch: ARM64
+            os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
arm64 linux runners now available in GHA

see tracking issue - https://github.com/pact-foundation/roadmap/issues/19#issuecomment-2603270897

This PR adds coverage for linux arm64 (glibc) platforms in our CI