### PR TITLE
feat!: Invoke async message scenario factories on request

### DIFF
--- a/src/PactNet.Abstractions/Verifier/Messaging/IMessageScenarioBuilder.cs
+++ b/src/PactNet.Abstractions/Verifier/Messaging/IMessageScenarioBuilder.cs
@@ -17,29 +17,29 @@ namespace PactNet.Verifier.Messaging
         IMessageScenarioBuilder WithMetadata(dynamic metadata);
 
         /// <summary>
-        /// Set the action of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
         void WithContent(Func<dynamic> factory);
 
         /// <summary>
-        /// Set the content of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
         /// <param name="settings">Custom JSON serializer settings</param>
         void WithContent(Func<dynamic> factory, JsonSerializerOptions settings);
 
         /// <summary>
-        /// Set the action of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
-        Task WithContentAsync(Func<Task<dynamic>> factory);
+        void WithAsyncContent(Func<Task<dynamic>> factory);
 
         /// <summary>
-        /// Set the content of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
         /// <param name="settings">Custom JSON serializer settings</param>
-        Task WithContentAsync(Func<Task<dynamic>> factory, JsonSerializerOptions settings);
+        void WithAsyncContent(Func<Task<dynamic>> factory, JsonSerializerOptions settings);
     }
 }

--- a/src/PactNet.Abstractions/Verifier/Messaging/IMessageScenarios.cs
+++ b/src/PactNet.Abstractions/Verifier/Messaging/IMessageScenarios.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace PactNet.Verifier.Messaging
 {
@@ -22,19 +21,11 @@ namespace PactNet.Verifier.Messaging
         IMessageScenarios Add(string description, Func<dynamic> factory);
 
         /// <summary>
-        /// Add a message scenario
+        /// Add a message scenario by configuring a scenario builder
         /// </summary>
         /// <param name="description">Scenario description</param>
         /// <param name="configure">Scenario configure</param>
-        /// <returns></returns>
+        /// <returns>Fluent builder</returns>
         IMessageScenarios Add(string description, Action<IMessageScenarioBuilder> configure);
-
-        /// <summary>
-        /// Add a message scenario
-        /// </summary>
-        /// <param name="description">Scenario description</param>
-        /// <param name="configure">Scenario configure</param>
-        /// <returns></returns>
-        IMessageScenarios Add(string description, Func<IMessageScenarioBuilder, Task> configure);
     }
 }

--- a/src/PactNet/Verifier/Messaging/MessageScenarioBuilder.cs
+++ b/src/PactNet/Verifier/Messaging/MessageScenarioBuilder.cs
@@ -10,6 +10,7 @@ namespace PactNet.Verifier.Messaging
     internal class MessageScenarioBuilder : IMessageScenarioBuilder
     {
         private readonly string description;
+
         private Func<dynamic> factory;
         private dynamic metadata = new { ContentType = "application/json" };
         private JsonSerializerOptions settings;
@@ -55,25 +56,32 @@ namespace PactNet.Verifier.Messaging
         }
 
         /// <summary>
-        /// Set the action of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
-        public async Task WithContentAsync(Func<Task<dynamic>> factory)
+        public void WithAsyncContent(Func<Task<dynamic>> factory)
         {
-            dynamic value = await factory();
-            this.factory = () => value;
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            this.WithContent(() => factory().GetAwaiter().GetResult());
         }
 
         /// <summary>
-        /// Set the content of the scenario
+        /// Set the content factory of the scenario. The factory is invoked each time the scenario is required.
         /// </summary>
         /// <param name="factory">Content factory</param>
         /// <param name="settings">Custom JSON serializer settings</param>
-        public async Task WithContentAsync(Func<Task<dynamic>> factory, JsonSerializerOptions settings)
+        public void WithAsyncContent(Func<Task<dynamic>> factory, JsonSerializerOptions settings)
         {
-            dynamic value = await factory();
-            this.factory = () => value;
-            this.settings = settings;
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            this.WithContent(() => factory().GetAwaiter().GetResult(), settings);
         }
 
         /// <summary>

--- a/src/PactNet/Verifier/Messaging/MessageScenarios.cs
+++ b/src/PactNet/Verifier/Messaging/MessageScenarios.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 
 namespace PactNet.Verifier.Messaging
 {
@@ -44,32 +43,15 @@ namespace PactNet.Verifier.Messaging
         }
 
         /// <summary>
-        /// Add a message scenario
+        /// Add a message scenario by configuring a scenario builder
         /// </summary>
         /// <param name="description">Scenario description</param>
         /// <param name="configure">Scenario configure</param>
-        /// <returns></returns>
+        /// <returns>Fluent builder</returns>
         public IMessageScenarios Add(string description, Action<IMessageScenarioBuilder> configure)
         {
             var builder = new MessageScenarioBuilder(description);
             configure?.Invoke(builder);
-
-            Scenario scenario = builder.Build();
-            this.scenarios.Add(description, scenario);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Add a message scenario
-        /// </summary>
-        /// <param name="description">Scenario description</param>
-        /// <param name="configure">Scenario configure</param>
-        /// <returns></returns>
-        public IMessageScenarios Add(string description, Func<IMessageScenarioBuilder, Task> configure)
-        {
-            var builder = new MessageScenarioBuilder(description);
-            configure?.Invoke(builder).GetAwaiter().GetResult();
 
             Scenario scenario = builder.Build();
             this.scenarios.Add(description, scenario);

--- a/tests/PactNet.Tests/Verifier/Messaging/MessageScenarioBuilderTests.cs
+++ b/tests/PactNet.Tests/Verifier/Messaging/MessageScenarioBuilderTests.cs
@@ -64,22 +64,22 @@ namespace PactNet.Tests.Verifier.Messaging
         }
 
         [Fact]
-        public async Task WithContentAsync_WhenCalled_SetsContent()
+        public void WithAsyncContent_WhenCalled_SetsContent()
         {
             dynamic expected = new { Foo = 42 };
 
-            await this.builder.WithContentAsync(() => Task.FromResult<dynamic>(expected));
+            this.builder.WithAsyncContent(() => Task.FromResult<dynamic>(expected));
             object actual = this.builder.Build().Invoke();
 
             actual.Should().Be(expected);
         }
 
         [Fact]
-        public async Task WithContentAsync_WithCustomSettings_SetsSettings()
+        public void WithAsyncContent_WithCustomSettings_SetsSettings()
         {
             var expected = new JsonSerializerOptions();
 
-            await this.builder.WithContentAsync(() => Task.FromResult<dynamic>(new { Foo = "Bar" }), expected);
+            this.builder.WithAsyncContent(() => Task.FromResult<dynamic>(new { Foo = "Bar" }), expected);
             var actual = this.builder.Build().JsonSettings;
 
             actual.Should().Be(expected);

--- a/tests/PactNet.Tests/Verifier/Messaging/MessageScenariosTests.cs
+++ b/tests/PactNet.Tests/Verifier/Messaging/MessageScenariosTests.cs
@@ -52,7 +52,7 @@ namespace PactNet.Tests.Verifier.Messaging
             Func<Task<dynamic>> factory = () => Task.FromResult<dynamic>(new { Foo = 42 });
             JsonSerializerOptions settings = new JsonSerializerOptions();
 
-            this.scenarios.Add("description", async builder => await builder.WithMetadata(metadata).WithContentAsync(factory, settings));
+            this.scenarios.Add("description", builder => builder.WithMetadata(metadata).WithAsyncContent(factory, settings));
 
             this.scenarios.Scenarios.Should().BeEquivalentTo(new Dictionary<string, Scenario>
             {


### PR DESCRIPTION
We still have to invoke the factory with sync-over-async at request time and this puts a burden on the user not to use this improperly, but if we want to delay invocation of the factory until after provider states have been configured then this is the first step.

This is also obviously a breaking API change and requires a major version bump. `WithAsyncContent` makes way more sense because it's the content factory that's async, not the call to the builder as `WithContentAsync` would imply. This also means the return type changes to void instead of Task.

See #459

We should also investigate making the internal messaging server itself async so that we don't have to do the sync-over-async shenanigans, which could maybe be achieved with `Task.Run` (or similar) instead of using a dedicated thread. We'd probably then also change the signature of `Scenario.Factory` to be `Func<Task<dynamic>>` instead, and the sync versions would wrap in `Task.FromResult`.

We do get really weird behaviour when using `dynamic` inside `Func<>` though, so this has to be carefully investigated, and may not be possible.