### PR TITLE
feat: pactbuilder can be properly disposed

### DIFF
--- a/samples/OrdersApi/Consumer.Tests/OrderCreatedConsumerTests.cs
+++ b/samples/OrdersApi/Consumer.Tests/OrderCreatedConsumerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Moq;
 using PactNet;
@@ -9,7 +10,7 @@ using Match = PactNet.Matchers.Match;
 
 namespace Consumer.Tests
 {
-    public class OrderCreatedConsumerTests
+    public sealed class OrderCreatedConsumerTests : IDisposable
     {
         private readonly OrderCreatedConsumer consumer;
         private readonly Mock<IFulfilmentService> mockService;
@@ -37,6 +38,9 @@ namespace Consumer.Tests
 
             this.pact = Pact.V4("Fulfilment API", "Orders API", config).WithMessageInteractions();
         }
+
+        public void Dispose() => this.pact.Dispose();
+
 
         [Fact]
         public async Task OnMessageAsync_OrderCreated_HandlesMessage()

--- a/samples/OrdersApi/Consumer.Tests/OrdersClientTests.cs
+++ b/samples/OrdersApi/Consumer.Tests/OrdersClientTests.cs
@@ -16,7 +16,7 @@ using Match = PactNet.Matchers.Match;
 
 namespace Consumer.Tests
 {
-    public class OrdersClientTests
+    public sealed class OrdersClientTests : IDisposable
     {
         private readonly IPactBuilderV4 pact;
         private readonly Mock<IHttpClientFactory> mockFactory;
@@ -43,6 +43,8 @@ namespace Consumer.Tests
 
             this.pact = Pact.V4("Fulfilment API", "Orders API", config).WithHttpInteractions();
         }
+
+        public void Dispose() => this.pact.Dispose();
 
         [Fact]
         public async Task GetOrderAsync_WhenCalled_ReturnsOrder()

--- a/src/PactNet.Abstractions/IMessagePactBuilder.cs
+++ b/src/PactNet.Abstractions/IMessagePactBuilder.cs
@@ -1,9 +1,18 @@
+using System;
+
 namespace PactNet
 {
     /// <summary>
+    /// Message Pact Builder
+    /// </summary>
+    public interface IMessagePactBuilder : IDisposable
+    {
+    }
+
+    /// <summary>
     /// Message pact v3 Builder
     /// </summary>
-    public interface IMessagePactBuilderV3
+    public interface IMessagePactBuilderV3 : IMessagePactBuilder
     {
         /// <summary>
         /// Add a new message to the pact
@@ -25,7 +34,7 @@ namespace PactNet
     /// <summary>
     /// Message pact v4 Builder
     /// </summary>
-    public interface IMessagePactBuilderV4
+    public interface IMessagePactBuilderV4 : IMessagePactBuilder
     {
         /// <summary>
         /// Add a new message to the pact

--- a/src/PactNet.Abstractions/IPactBuilder.cs
+++ b/src/PactNet.Abstractions/IPactBuilder.cs
@@ -7,7 +7,7 @@ namespace PactNet
     /// <summary>
     /// Pact Builder
     /// </summary>
-    public interface IPactBuilder
+    public interface IPactBuilder : IDisposable
     {
         /// <summary>
         /// Verify the configured interactions

--- a/src/PactNet/Drivers/HttpPactDriver.cs
+++ b/src/PactNet/Drivers/HttpPactDriver.cs
@@ -57,5 +57,30 @@ namespace PactNet.Drivers
                 _ => new InvalidOperationException($"Unknown mock server error: {result}")
             };
         }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Allows an object to try to free resources and perform other cleanup operations before it is reclaimed by garbage collection.
+        /// </summary>
+        ~HttpPactDriver()
+        {
+            this.ReleaseUnmanagedResources();
+        }
+
+        /// <summary>
+        /// Release unmanaged resources
+        /// </summary>
+        private void ReleaseUnmanagedResources()
+        {
+            NativeInterop.FreePact(this.pact);
+        }
     }
 }

--- a/src/PactNet/Drivers/IHttpPactDriver.cs
+++ b/src/PactNet/Drivers/IHttpPactDriver.cs
@@ -5,7 +5,7 @@ namespace PactNet.Drivers
     /// <summary>
     /// Driver for synchronous HTTP pacts
     /// </summary>
-    internal interface IHttpPactDriver : ICompletedPactDriver
+    internal interface IHttpPactDriver : ICompletedPactDriver, IDisposable
     {
         /// <summary>
         /// Create a new interaction on the current pact

--- a/src/PactNet/Drivers/IMessagePactDriver.cs
+++ b/src/PactNet/Drivers/IMessagePactDriver.cs
@@ -1,9 +1,11 @@
-﻿namespace PactNet.Drivers
+﻿using System;
+
+namespace PactNet.Drivers
 {
     /// <summary>
     /// Driver for message pacts
     /// </summary>
-    internal interface IMessagePactDriver
+    internal interface IMessagePactDriver : IDisposable
     {
         /// <summary>
         /// Create a new message interaction on the current pact

--- a/src/PactNet/Drivers/MessagePactDriver.cs
+++ b/src/PactNet/Drivers/MessagePactDriver.cs
@@ -1,4 +1,5 @@
-﻿using PactNet.Interop;
+﻿using System;
+using PactNet.Interop;
 
 namespace PactNet.Drivers
 {
@@ -37,5 +38,30 @@ namespace PactNet.Drivers
         /// <param name="value">the value of the parameter</param>
         public void WithMessagePactMetadata(string @namespace, string name, string value)
             => NativeInterop.WithMessagePactMetadata(this.pact, @namespace, name, value);
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Allows an object to try to free resources and perform other cleanup operations before it is reclaimed by garbage collection.
+        /// </summary>
+        ~MessagePactDriver()
+        {
+            this.ReleaseUnmanagedResources();
+        }
+
+        /// <summary>
+        /// Release unmanaged resources
+        /// </summary>
+        private void ReleaseUnmanagedResources()
+        {
+            NativeInterop.FreeMessagePact(this.pact);
+        }
     }
 }

--- a/src/PactNet/Drivers/PactDriver.cs
+++ b/src/PactNet/Drivers/PactDriver.cs
@@ -31,7 +31,7 @@ namespace PactNet.Drivers
         /// <returns>Message pact driver driver</returns>
         public IMessagePactDriver NewMessagePact(string consumerName, string providerName, PactSpecification version)
         {
-            PactHandle pact = NativeInterop.NewPact(consumerName, providerName);
+            PactHandle pact = NativeInterop.NewMessagePact(consumerName, providerName);
             NativeInterop.WithSpecification(pact, version).CheckInteropSuccess();
 
             return new MessagePactDriver(pact);

--- a/src/PactNet/Interop/NativeInterop.cs
+++ b/src/PactNet/Interop/NativeInterop.cs
@@ -36,6 +36,9 @@ namespace PactNet.Interop
         [DllImport(DllName, EntryPoint = "pactffi_new_pact")]
         public static extern PactHandle NewPact(string consumerName, string providerName);
 
+        [DllImport(DllName, EntryPoint = "pactffi_free_pact_handle")]
+        public static extern uint FreePact(PactHandle pact);
+
         [DllImport(DllName, EntryPoint = "pactffi_with_specification")]
         public static extern bool WithSpecification(PactHandle pact, PactSpecification version);
 
@@ -72,6 +75,12 @@ namespace PactNet.Interop
         #endregion Http Interop Support
 
         #region Messaging Interop Support
+
+        [DllImport(DllName, EntryPoint = "pactffi_new_message_pact")]
+        public static extern PactHandle NewMessagePact(string consumerName, string providerName);
+
+        [DllImport(DllName, EntryPoint = "pactffi_free_message_pact_handle")]
+        public static extern uint FreeMessagePact(PactHandle pact);
 
         [DllImport(DllName, EntryPoint = "pactffi_with_message_pact_metadata")]
         public static extern void WithMessagePactMetadata(PactHandle pact, string @namespace, string name, string value);

--- a/src/PactNet/MessagePactBuilder.cs
+++ b/src/PactNet/MessagePactBuilder.cs
@@ -73,5 +73,13 @@ namespace PactNet
             this.driver.WithMessagePactMetadata(@namespace, name, value);
             return this;
         }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.driver.Dispose();
+        }
     }
 }

--- a/src/PactNet/PactBuilder.cs
+++ b/src/PactNet/PactBuilder.cs
@@ -172,5 +172,13 @@ namespace PactNet
             this.config.WriteLine(string.Empty);
             this.config.WriteLine(logs);
         }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.pact.Dispose();
+        }
     }
 }


### PR DESCRIPTION
When creating `PactHandle` with `pactffi_new_pact`, it need to be freed with `pactffi_free_pact_handle`.

I implement Disposable interface but not sure how to handle unmanaged resource with finalizer.

BTW, I see that pactffi has a dedicated method for message interactions (`pactffi_new_message_pact`,  `pactffi_free_message_pact_handle`) and use them. It doesn't change the way the consumer test generate its pact file.